### PR TITLE
fix: Upgrade dependency to avoid security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5132,9 +5132,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-			"integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+			"integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
@@ -10273,9 +10273,9 @@
 			}
 		},
 		"protobufjs": {
-			"version": "6.11.2",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-			"integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+			"integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",


### PR DESCRIPTION
protobufjs below 6.11.3 is vulnerable to [prototype pollution](https://learn.snyk.io/lessons/prototype-pollution/javascript/)