### PR TITLE
feat: Added InsertOrReplace operation on collection

### DIFF
--- a/src/__tests__/test-service.ts
+++ b/src/__tests__/test-service.ts
@@ -345,7 +345,27 @@ export class TestTigrisService {
 			call: ServerUnaryCall<ReplaceRequest, ReplaceResponse>,
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			callback: sendUnaryData<ReplaceResponse>
-		): void {},
+		): void {
+			if (call.request.getDb() === "test-tx") {
+				const txIdHeader = call.metadata.get("Tigris-Tx-Id").toString();
+				const txOriginHeader = call.metadata.get("Tigris-Tx-Origin").toString();
+				if (txIdHeader != TestTigrisService.txId || txOriginHeader != TestTigrisService.txOrigin) {
+					callback(new Error("transaction mismatch - insertOrReplace"));
+					return;
+				}
+			}
+			const reply: ReplaceResponse = new ReplaceResponse();
+			reply.setStatus(
+				"insertedOrReplaced: " +
+				JSON.stringify(new TextDecoder().decode(call.request.getDocumentsList_asU8()[0]))
+			);
+			reply.setMetadata(
+				new ResponseMetadata()
+					.setCreatedAt(new google_protobuf_timestamp_pb.Timestamp())
+					.setUpdatedAt(new google_protobuf_timestamp_pb.Timestamp())
+			);
+			callback(undefined, reply);
+		},
 		rollbackTransaction(
 			call: ServerUnaryCall<RollbackTransactionRequest, RollbackTransactionResponse>,
 			callback: sendUnaryData<RollbackTransactionResponse>

--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -2,7 +2,6 @@ import {Server, ServerCredentials} from '@grpc/grpc-js';
 import {TigrisService} from '../proto/server/v1/api_grpc_pb';
 import TestService, {TestTigrisService} from './test-service';
 import {
-	CollectionSchemaDefinition,
 	DatabaseOptions,
 	LogicalOperator,
 	SelectorFilterOperator,
@@ -168,6 +167,22 @@ describe('success rpc tests', () => {
 			expect(value.status).toBe('inserted: "{\\"author\\":\\"author name\\",\\"id\\":0,\\"tags\\":[\\"science\\"],\\"title\\":\\"science book\\"}"');
 		})
 		return insertionPromise;
+	});
+
+	it('insertOrReplace', () => {
+		const tigris = new Tigris({serverUrl: '0.0.0.0:' + SERVER_PORT});
+		const db1 = tigris.getDatabase('db3');
+		const insertOrReplacePromise = db1.getCollection<IBook>('books').insertOrReplace({
+			author: "author name",
+			id: 0,
+			tags: ['science'],
+			title: 'science book'
+		});
+		insertOrReplacePromise.then(value => {
+			expect(value.status).toBe('insertedOrReplaced: "{\\"author\\":\\"author' +
+				' name\\",\\"id\\":0,\\"tags\\":[\\"science\\"],\\"title\\":\\"science book\\"}"');
+		})
+		return insertOrReplacePromise;
 	});
 
 	it('delete', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,14 @@ export class InsertResponse extends DMLResponse {
 
 }
 
+export class InsertOrReplaceResponse extends DMLResponse {
+
+	constructor(status: string, metadata: DMLMetadata) {
+		super(status, metadata);
+	}
+
+}
+
 export class DeleteResponse extends DMLResponse {
 
 	constructor(status: string, metadata: DMLMetadata) {
@@ -238,23 +246,9 @@ export class RollbackTransactionResponse extends TigrisResponse {
 	}
 }
 
-export class InsertOptions {
-	private readonly _status: string;
-	private readonly _message: string;
+export class InsertOptions {}
 
-	constructor(status: string, message: string) {
-		this._status = status;
-		this._message = message;
-	}
-
-	get status(): string {
-		return this._status;
-	}
-
-	get message(): string {
-		return this._message;
-	}
-}
+export class InsertOrReplaceOptions {}
 
 
 // Marker interface
@@ -309,10 +303,6 @@ export enum TigrisDataTypes {
 	ARRAY = 'array'
 }
 
-export type CollectionSchemaDefinition<T> = {
-	collectionName: string;
-	schema: TigrisSchema<T>;
-}
 export type TigrisSchema<T> = {
 	[K in keyof T]: (
 		{


### PR DESCRIPTION
TODO: 
 - stitch the generated keys back to docs for both insert and insertOrReplace (in later diff)

Usage:

```
db.getCollection<IBook>('books').insertOrReplace({
	author: "author name",
	id: 1,
	tags: ['science'],
	title: 'science book'
});
```