### PR TITLE
feat!: Return new documents with keys set.

### DIFF
--- a/src/__tests__/data/basicCollection.json
+++ b/src/__tests__/data/basicCollection.json
@@ -4,7 +4,8 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "number",
+      "type": "integer",
+      "format": "int32",
       "autoGenerate": true
     },
     "name": {
@@ -15,11 +16,11 @@
       "format": "uuid"
     },
     "int32Number": {
-      "type": "number",
+      "type": "integer",
       "format": "int32"
     },
     "int64Number": {
-      "type": "number",
+      "type": "integer",
       "format": "int64"
     },
     "date": {

--- a/src/__tests__/data/multiplePKeys.json
+++ b/src/__tests__/data/multiplePKeys.json
@@ -4,7 +4,8 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "number"
+      "type": "integer",
+      "format": "int64"
     },
     "name": {
       "type": "string"
@@ -15,11 +16,11 @@
       "autoGenerate": true
     },
     "int32Number": {
-      "type": "number",
+      "type": "integer",
       "format": "int32"
     },
     "int64Number": {
-      "type": "number",
+      "type": "integer",
       "format": "int64"
     },
     "date": {

--- a/src/__tests__/test-service.ts
+++ b/src/__tests__/test-service.ts
@@ -1,10 +1,12 @@
-import { ITigrisServer, TigrisService } from "../proto/server/v1/api_grpc_pb";
-import { sendUnaryData, ServerUnaryCall, ServerWritableStream } from "@grpc/grpc-js";
-import { v4 as uuidv4 } from "uuid";
+import {ITigrisServer, TigrisService} from "../proto/server/v1/api_grpc_pb";
+import {sendUnaryData, ServerUnaryCall, ServerWritableStream} from "@grpc/grpc-js";
+import {v4 as uuidv4} from "uuid";
 import {
 	BeginTransactionRequest,
 	BeginTransactionResponse,
+	CollectionDescription,
 	CollectionInfo,
+	CollectionMetadata,
 	CommitTransactionRequest,
 	CommitTransactionResponse,
 	CreateDatabaseRequest,
@@ -23,6 +25,8 @@ import {
 	DropCollectionResponse,
 	DropDatabaseRequest,
 	DropDatabaseResponse,
+	GetInfoRequest,
+	GetInfoResponse,
 	InsertRequest,
 	InsertResponse,
 	ListCollectionsRequest,
@@ -33,21 +37,17 @@ import {
 	ReadResponse,
 	ReplaceRequest,
 	ReplaceResponse,
+	ResponseMetadata,
 	RollbackTransactionRequest,
 	RollbackTransactionResponse,
 	StreamRequest,
 	StreamResponse,
+	TransactionCtx,
 	UpdateRequest,
 	UpdateResponse,
-	CollectionMetadata,
-	CollectionDescription,
-	ResponseMetadata,
-	GetInfoRequest,
-	GetInfoResponse,
-	TransactionCtx,
 } from "../proto/server/v1/api_pb";
 import * as google_protobuf_timestamp_pb from "google-protobuf/google/protobuf/timestamp_pb";
-import { Utility } from "./../utility";
+import {Utility} from "./../utility";
 
 export class TestTigrisService {
 	private static DBS: string[] = [];
@@ -214,9 +214,14 @@ export class TestTigrisService {
 				}
 			}
 			const reply: InsertResponse = new InsertResponse();
+			const keyList: Array<string> = [];
+			for (let i = 1; i <= call.request.getDocumentsList().length; i++) {
+				keyList.push(Utility._base64Encode('{"id":' + i + '}'));
+			}
+			reply.setKeysList(keyList)
 			reply.setStatus(
 				"inserted: " +
-					JSON.stringify(new TextDecoder().decode(call.request.getDocumentsList_asU8()[0]))
+				JSON.stringify(new TextDecoder().decode(call.request.getDocumentsList_asU8()[0]))
 			);
 			reply.setMetadata(
 				new ResponseMetadata()
@@ -355,6 +360,11 @@ export class TestTigrisService {
 				}
 			}
 			const reply: ReplaceResponse = new ReplaceResponse();
+			const keyList: Array<string> = [];
+			for (let i = 1; i <= call.request.getDocumentsList().length; i++) {
+				keyList.push(Utility._base64Encode('{"id":' + i + '}'));
+			}
+			reply.setKeysList(keyList);
 			reply.setStatus(
 				"insertedOrReplaced: " +
 				JSON.stringify(new TextDecoder().decode(call.request.getDocumentsList_asU8()[0]))
@@ -392,9 +402,9 @@ export class TestTigrisService {
 			const reply: UpdateResponse = new UpdateResponse();
 			reply.setStatus(
 				"updated: " +
-					Utility.uint8ArrayToString(call.request.getFilter_asU8()) +
-					", " +
-					Utility.uint8ArrayToString(call.request.getFields_asU8())
+				Utility.uint8ArrayToString(call.request.getFilter_asU8()) +
+				", " +
+				Utility.uint8ArrayToString(call.request.getFields_asU8())
 			);
 			reply.setMetadata(
 				new ResponseMetadata()

--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -163,9 +163,9 @@ describe('success rpc tests', () => {
 			tags: ['science'],
 			title: 'science book'
 		});
-		insertionPromise.then(value => {
-			expect(value.status).toBe('inserted: "{\\"author\\":\\"author name\\",\\"id\\":0,\\"tags\\":[\\"science\\"],\\"title\\":\\"science book\\"}"');
-		})
+		insertionPromise.then(insertedBook => {
+			expect(insertedBook.id).toBe(1)
+		});
 		return insertionPromise;
 	});
 
@@ -178,9 +178,8 @@ describe('success rpc tests', () => {
 			tags: ['science'],
 			title: 'science book'
 		});
-		insertOrReplacePromise.then(value => {
-			expect(value.status).toBe('insertedOrReplaced: "{\\"author\\":\\"author' +
-				' name\\",\\"id\\":0,\\"tags\\":[\\"science\\"],\\"title\\":\\"science book\\"}"');
+		insertOrReplacePromise.then(insertedOrReplacedBook => {
+			expect(insertedOrReplacedBook.id).toBe(1)
 		})
 		return insertOrReplacePromise;
 	});
@@ -427,7 +426,7 @@ describe('success rpc tests', () => {
 			expect(value.message).toBe('Collections created successfully');
 			// for test mock service returning schema to validate the schema was properly
 			// constructed and seen by server
-			expect(value.status).toBe('{"title":"books","additionalProperties":false,"type":"object","properties":{"id":{"type":"number","format":"int64","autoGenerate":true},"author":{"type":"string"},"title":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}}},"primary_key":["id"]}');
+			expect(value.status).toBe('{"title":"books","additionalProperties":false,"type":"object","properties":{"id":{"type":"integer","format":"int64","autoGenerate":true},"author":{"type":"string"},"title":{"type":"string"},"tags":{"type":"array","items":{"type":"string"}}},"primary_key":["id"]}');
 		});
 	});
 });

--- a/src/__tests__/tigris.schema.spec.ts
+++ b/src/__tests__/tigris.schema.spec.ts
@@ -6,7 +6,7 @@ describe('schema tests', () => {
 	it('basicCollection', () => {
 		const schema: TigrisSchema<BasicCollection> = {
 			id: {
-				type: TigrisDataTypes.NUMBER,
+				type: TigrisDataTypes.INT32,
 				primary_key: {
 					order: 1,
 					autoGenerate: true
@@ -38,7 +38,7 @@ describe('schema tests', () => {
 	it('multiplePKeys', () => {
 		const schema: TigrisSchema<BasicCollection> = {
 			id: {
-				type: TigrisDataTypes.NUMBER,
+				type: TigrisDataTypes.INT64,
 				primary_key: {
 					order: 2, // intentionally the order is skewed to test
 				}

--- a/src/db.ts
+++ b/src/db.ts
@@ -39,11 +39,13 @@ export class DB {
 	public createOrUpdateCollection<T extends TigrisCollectionType>(
 		collectionName: string, schema: TigrisSchema<T>): Promise<CreateOrUpdateCollectionsResponse> {
 		return new Promise<CreateOrUpdateCollectionsResponse>((resolve, reject) => {
+			const rawJSONSchema: string = Utility._toJSONSchema(collectionName, schema);
+			console.log(rawJSONSchema)
 			const createOrUpdateCollectionRequest = new ProtoCreateOrUpdateCollectionRequest()
 				.setDb(this._db)
 				.setCollection(collectionName)
 				.setOnlyCreate(false)
-				.setSchema(Utility.stringToUint8Array(Utility._toJSONSchema(collectionName, schema)))
+				.setSchema(Utility.stringToUint8Array(rawJSONSchema))
 
 			this.grpcClient.createOrUpdateCollection(
 				createOrUpdateCollectionRequest,

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,22 +173,6 @@ export class DMLResponse extends TigrisResponse {
 	}
 }
 
-export class InsertResponse extends DMLResponse {
-
-	constructor(status: string, metadata: DMLMetadata) {
-		super(status, metadata);
-	}
-
-}
-
-export class InsertOrReplaceResponse extends DMLResponse {
-
-	constructor(status: string, metadata: DMLMetadata) {
-		super(status, metadata);
-	}
-
-}
-
 export class DeleteResponse extends DMLResponse {
 
 	constructor(status: string, metadata: DMLMetadata) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -240,8 +240,9 @@ export const Utility = {
 		switch (fieldType.valueOf()) {
 			case TigrisDataTypes.INT32:
 			case TigrisDataTypes.INT64:
-			case TigrisDataTypes.NUMBER:
 			case TigrisDataTypes.NUMBER_BIGINT:
+				return 'integer';
+			case TigrisDataTypes.NUMBER:
 				return 'number';
 			case TigrisDataTypes.STRING:
 			case TigrisDataTypes.UUID:
@@ -270,5 +271,11 @@ export const Utility = {
 
 	_readTestDataFile(path: string): string {
 		return Utility.objToJsonString(Utility.jsonStringToObj(fs.readFileSync('src/__tests__/data/'+path, 'utf8')));
+	},
+	_base64Encode(input: string): string {
+		return Buffer.from(input).toString("base64");
+	},
+	_base64Decode(b64String: string): string {
+		return Buffer.from(b64String).toString("binary");
 	},
 };


### PR DESCRIPTION
Return new documents with keys set.

Usage

```
books.insert({
    author: "author name",
    id: 0, // <---- note 0 to let server generate it.
    tags: ['science'],
    title: 'science book'
}).then(insertedBook => {
    // insertedBook.id is set here
});
```

```
books.insertOrReplace({
    author: "author name",
    id: 0, // <---- note 0 to let server generate it.
    tags: ['science'],
    title: 'science book'
}).then(insertedOrReplacedBook => {
    // insertedOrReplacedBook.id is set here
});
```


bug fixes:
 - schema generation number type fixed to use integer (for int32/int64 fields)
 