### PR TITLE
fix!: Return a response on transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tigrisdata/core",
-	"version": "1.0.0-alpha.6",
+	"version": "1.0.0-alpha.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tigrisdata/core",
-			"version": "1.0.0-alpha.6",
+			"version": "1.0.0-alpha.7",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.6.7",
 				"google-protobuf": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tigrisdata/core",
-	"version": "1.0.0-alpha.6",
+	"version": "1.0.0-alpha.7",
 	"description": "Tigris client for Typescript",
 	"author": "Tigris Data (https://www.tigrisdata.com/)",
 	"contributors": [

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,11 @@ export class RollbackTransactionResponse extends TigrisResponse {
 	}
 }
 
+export class TransactionResponse extends TigrisResponse {
+	constructor(status: string) {
+		super(status);
+	}
+}
 export class InsertOptions {}
 
 export class InsertOrReplaceOptions {}


### PR DESCRIPTION
In case if user passes in `async` function, this will allow them to wait on transaction to finish.

something like

```
await db.transact(async (tx) => {...});
```
(this will now only finish once we resolve the promise) 

- prepare for next release.