### PR TITLE
feat: Simpler SelectorFilter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tigrisdata/core",
-	"version": "1.0.0-alpha.7",
+	"version": "1.0.0-alpha.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tigrisdata/core",
-			"version": "1.0.0-alpha.7",
+			"version": "1.0.0-alpha.8",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.6.7",
 				"google-protobuf": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tigrisdata/core",
-	"version": "1.0.0-alpha.7",
+	"version": "1.0.0-alpha.8",
 	"description": "Tigris client for Typescript",
 	"author": "Tigris Data (https://www.tigrisdata.com/)",
 	"contributors": [

--- a/src/__tests__/test-service.ts
+++ b/src/__tests__/test-service.ts
@@ -213,10 +213,16 @@ export class TestTigrisService {
 					return;
 				}
 			}
+
 			const reply: InsertResponse = new InsertResponse();
 			const keyList: Array<string> = [];
 			for (let i = 1; i <= call.request.getDocumentsList().length; i++) {
-				keyList.push(Utility._base64Encode('{"id":' + i + '}'));
+				if(call.request.getCollection() === 'books-with-optional-field'){
+					const extractedKeyFromAuthor: number = JSON.parse(Utility._base64Decode(call.request.getDocumentsList_asB64()[i-1]))['author'];
+					keyList.push(Utility._base64Encode('{"id":'+extractedKeyFromAuthor+'}'));
+				} else {
+					keyList.push(Utility._base64Encode('{"id":' + i + '}'));
+				}
 			}
 			reply.setKeysList(keyList);
 			reply.setStatus(
@@ -362,7 +368,12 @@ export class TestTigrisService {
 			const reply: ReplaceResponse = new ReplaceResponse();
 			const keyList: Array<string> = [];
 			for (let i = 1; i <= call.request.getDocumentsList().length; i++) {
-				keyList.push(Utility._base64Encode('{"id":' + i + '}'));
+				if(call.request.getCollection() === 'books-with-optional-field'){
+					const extractedKeyFromAuthor: number = JSON.parse(Utility._base64Decode(call.request.getDocumentsList_asB64()[i-1]))['author'];
+					keyList.push(Utility._base64Encode('{"id":'+extractedKeyFromAuthor+'}'));
+				} else {
+					keyList.push(Utility._base64Encode('{"id":' + i + '}'));
+				}
 			}
 			reply.setKeysList(keyList);
 			reply.setStatus(

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -1,14 +1,30 @@
 import {
 	LogicalFilter,
-	LogicalOperator,
+	LogicalOperator, Selector,
 	SelectorFilter,
 	SelectorFilterOperator,
 	TigrisCollectionType,
 } from "../types";
 import {Utility} from '../utility';
 
-describe('success tests', () => {
+describe('filters tests', () => {
+	it('simpleSelectorFilterTest', () => {
+		const filter1: Selector<IUser> = {
+				name: 'Alice'
+		};
+		expect(Utility.filterToString(filter1)).toBe('{"name":"Alice"}');
 
+		const filter2: Selector<IUser> = {
+			balance: 100
+		};
+		expect(Utility.filterToString(filter2)).toBe('{"balance":100}');
+
+		const filter3: Selector<IUser1> = {
+			isActive: true
+		};
+		expect(Utility.filterToString(filter3)).toBe('{"isActive":true}');
+
+	});
 	it('basicSelectorFilterTest', () => {
 		const filter1: SelectorFilter<IUser> = {
 			op: SelectorFilterOperator.EQ,
@@ -16,7 +32,7 @@ describe('success tests', () => {
 				name: 'Alice'
 			}
 		};
-		expect(Utility._selectorFilterToString(filter1)).toBe('{"name":"Alice"}');
+		expect(Utility.filterToString(filter1)).toBe('{"name":"Alice"}');
 
 		const filter2: SelectorFilter<IUser> = {
 			op: SelectorFilterOperator.EQ,
@@ -24,7 +40,7 @@ describe('success tests', () => {
 				id: BigInt(123)
 			}
 		};
-		expect(Utility._selectorFilterToString(filter2)).toBe('{"id":123}');
+		expect(Utility.filterToString(filter2)).toBe('{"id":123}');
 
 		const filter3: SelectorFilter<IUser1> = {
 			op: SelectorFilterOperator.EQ,
@@ -32,7 +48,7 @@ describe('success tests', () => {
 				isActive: true
 			}
 		};
-		expect(Utility._selectorFilterToString(filter3)).toBe('{"isActive":true}');
+		expect(Utility.filterToString(filter3)).toBe('{"isActive":true}');
 	});
 
 	it('selectorFilter_1', () => {
@@ -43,7 +59,7 @@ describe('success tests', () => {
 				name: 'alice',
 			}
 		};
-		expect(Utility._selectorFilterToString(tigrisFilter)).toBe('{"id":1,"name":"alice"}');
+		expect(Utility.filterToString(tigrisFilter)).toBe('{"id":1,"name":"alice"}');
 	});
 
 	it('selectorFilter_2', () => {
@@ -55,7 +71,7 @@ describe('success tests', () => {
 				balance: 12.34
 			}
 		};
-		expect(Utility._selectorFilterToString(tigrisFilter)).toBe('{"id":1,"name":"alice","balance":12.34}');
+		expect(Utility.filterToString(tigrisFilter)).toBe('{"id":1,"name":"alice","balance":12.34}');
 	});
 
 	it('selectorFilter_3', () => {
@@ -70,7 +86,7 @@ describe('success tests', () => {
 				}
 			}
 		};
-		expect(Utility._selectorFilterToString(tigrisFilter)).toBe('{"id":1,"name":"alice","balance":12.34,"address.city":"San Francisco"}');
+		expect(Utility.filterToString(tigrisFilter)).toBe('{"id":1,"name":"alice","balance":12.34,"address.city":"San Francisco"}');
 	});
 
 	it('logicalFilterTest1', () => {
@@ -91,7 +107,7 @@ describe('success tests', () => {
 				}
 			]
 		};
-		expect(Utility._logicalFilterToString(logicalFilter)).toBe('{"$or":[{"name":"alice"},{"name":"emma"}]}');
+		expect(Utility.filterToString(logicalFilter)).toBe('{"$or":[{"name":"alice"},{"name":"emma"}]}');
 	});
 
 	it('logicalFilterTest2', () => {
@@ -112,7 +128,7 @@ describe('success tests', () => {
 				}
 			]
 		};
-		expect(Utility._logicalFilterToString(logicalFilter)).toBe('{"$and":[{"name":"alice"},{"rank":1}]}');
+		expect(Utility.filterToString(logicalFilter)).toBe('{"$and":[{"name":"alice"},{"rank":1}]}');
 	});
 
 	it('nestedLogicalFilter1', () => {
@@ -154,7 +170,7 @@ describe('success tests', () => {
 			op: LogicalOperator.OR,
 			logicalFilters: [logicalFilter1, logicalFilter2]
 		};
-		expect(Utility._logicalFilterToString(nestedLogicalFilter)).toBe('{"$or":[{"$and":[{"name":"alice"},{"rank":1}]},{"$and":[{"name":"emma"},{"rank":1}]}]}');
+		expect(Utility.filterToString(nestedLogicalFilter)).toBe('{"$or":[{"$and":[{"name":"alice"},{"rank":1}]},{"$and":[{"name":"emma"},{"rank":1}]}]}');
 	});
 
 	it('nestedLogicalFilter2', () => {
@@ -196,7 +212,7 @@ describe('success tests', () => {
 			op: LogicalOperator.AND,
 			logicalFilters: [logicalFilter1, logicalFilter2]
 		};
-		expect(Utility._logicalFilterToString(nestedLogicalFilter)).toBe('{"$and":[{"$or":[{"name":"alice"},{"rank":1}]},{"$or":[{"name":"emma"},{"rank":1}]}]}');
+		expect(Utility.filterToString(nestedLogicalFilter)).toBe('{"$and":[{"$or":[{"name":"alice"},{"rank":1}]},{"$or":[{"name":"emma"},{"rank":1}]}]}');
 	});
 });
 

--- a/src/__tests__/tigris.jsonserde.spec.ts
+++ b/src/__tests__/tigris.jsonserde.spec.ts
@@ -3,7 +3,7 @@ import {
 } from "../types";
 import {Utility} from '../utility';
 
-describe('success tests', () => {
+describe('JSON serde tests', () => {
 
 	it('jsonSerDe', () => {
 		const user: IUser =

--- a/src/__tests__/tigris.readfields.spec.ts
+++ b/src/__tests__/tigris.readfields.spec.ts
@@ -3,7 +3,7 @@ import {
 } from "../types";
 import {Utility} from '../utility';
 
-describe('success tests', () => {
+describe('readFields tests', () => {
 	it('readFields1', () => {
 		const readFields: ReadFields = {
 			include: ['id', 'title'],

--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "../types";
 import {Tigris} from '../tigris';
 
-describe('success rpc tests', () => {
+describe('rpc tests', () => {
 	let server: Server;
 	const SERVER_PORT = 5002;
 	beforeAll(() => {
@@ -169,6 +169,23 @@ describe('success rpc tests', () => {
 		return insertionPromise;
 	});
 
+	it('insertWithOptionalField', () => {
+		const tigris = new Tigris({serverUrl: '0.0.0.0:' + SERVER_PORT});
+		const db1 = tigris.getDatabase('db3');
+		const randomNumber: number = Math.floor(Math.random() * 100);
+		// pass the random number in author field. mock server reads author and sets as the
+		// primaryKey field.
+		const insertionPromise = db1.getCollection<IBook1>('books-with-optional-field').insert({
+			author: "" + randomNumber,
+			tags: ['science'],
+			title: 'science book'
+		});
+		insertionPromise.then(insertedBook => {
+			expect(insertedBook.id).toBe(randomNumber);
+		});
+		return insertionPromise;
+	});
+
 	it('insertOrReplace', () => {
 		const tigris = new Tigris({serverUrl: '0.0.0.0:' + SERVER_PORT});
 		const db1 = tigris.getDatabase('db3');
@@ -180,6 +197,23 @@ describe('success rpc tests', () => {
 		});
 		insertOrReplacePromise.then(insertedOrReplacedBook => {
 			expect(insertedOrReplacedBook.id).toBe(1);
+		});
+		return insertOrReplacePromise;
+	});
+
+	it('insertOrReplaceWithOptionalField', () => {
+		const tigris = new Tigris({serverUrl: '0.0.0.0:' + SERVER_PORT});
+		const db1 = tigris.getDatabase('db3');
+		const randomNumber: number = Math.floor(Math.random() * 100);
+		// pass the random number in author field. mock server reads author and sets as the
+		// primaryKey field.
+		const insertOrReplacePromise = db1.getCollection<IBook1>('books-with-optional-field').insertOrReplace({
+			author: "" + randomNumber,
+			tags: ['science'],
+			title: 'science book'
+		});
+		insertOrReplacePromise.then(insertedOrReplacedBook => {
+			expect(insertedOrReplacedBook.id).toBe(randomNumber);
 		});
 		return insertOrReplacePromise;
 	});
@@ -438,6 +472,13 @@ describe('success rpc tests', () => {
 
 export interface IBook extends TigrisCollectionType {
 	id: number;
+	title: string;
+	author: string;
+	tags?: string[];
+}
+
+export interface IBook1 extends TigrisCollectionType {
+	id?: number;
 	title: string;
 	author: string;
 	tags?: string[];

--- a/src/__tests__/tigris.updatefields.spec.ts
+++ b/src/__tests__/tigris.updatefields.spec.ts
@@ -4,7 +4,7 @@ import {
 } from "../types";
 import {Utility} from '../utility';
 
-describe('success tests', () => {
+describe('updateFields tests', () => {
 
 	it('updateFields', () => {
 		const updateFields: UpdateFields = {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -24,6 +24,7 @@ import {
 	LogicalFilter,
 	ReadFields,
 	ReadRequestOptions,
+	Selector,
 	SelectorFilter,
 	TigrisCollectionType,
 	UpdateFields,
@@ -171,7 +172,7 @@ export class Collection<T extends TigrisCollectionType> {
 	}
 
 	readOne(
-		filter: SelectorFilter<T> | LogicalFilter<T>,
+		filter: SelectorFilter<T> | LogicalFilter<T> | Selector<T>,
 		tx?: Session,
 		readFields?: ReadFields,
 	): Promise<T | undefined> {
@@ -209,7 +210,7 @@ export class Collection<T extends TigrisCollectionType> {
 	}
 
 	read(
-		filter: SelectorFilter<T> | LogicalFilter<T>,
+		filter: SelectorFilter<T> | LogicalFilter<T> | Selector<T>,
 		reader: ReaderCallback<T>,
 		readFields?: ReadFields,
 		tx?: Session,
@@ -261,12 +262,12 @@ export class Collection<T extends TigrisCollectionType> {
 	}
 
 	delete(
-		filter: SelectorFilter<T> | LogicalFilter<T>,
+		filter: SelectorFilter<T> | LogicalFilter<T> | Selector<T>,
 		tx?: Session,
 		_options?: DeleteRequestOptions
 	): Promise<DeleteResponse> {
 		return new Promise<DeleteResponse>((resolve, reject) => {
-			if(!filter){
+			if (!filter) {
 				reject(new Error('No filter specified'))
 			}
 			const deleteRequest = new ProtoDeleteRequest()
@@ -297,7 +298,7 @@ export class Collection<T extends TigrisCollectionType> {
 	}
 
 	update(
-		filter: SelectorFilter<T> | LogicalFilter<T>,
+		filter: SelectorFilter<T> | LogicalFilter<T> | Selector<T>,
 		fields: UpdateFields,
 		tx?: Session,
 		_options?: UpdateRequestOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -385,7 +385,7 @@ type PathType<T, P extends string> = P extends keyof T
 			: never
 		: never;
 
-type Selector<T> = Partial<{
+export type Selector<T> = Partial<{
 	[K in Paths<T>]: Partial<PathType<T, K & string>>
 }>;
 


### PR DESCRIPTION
 - Simplified Selector filter for `$eq`

From

```
const filter: SelectorFilter<User> = {
 op: SelectorFilterOperator.EQ,
 fields: {
  name: 'Alice'
 }
}
```

to

```
const filter: Selector<User> = {
 name: 'Alice'
}
```

 - Added a test where primaryKey is generated on server and user may choose to not pass its value from client (0 magic value).
 - Prepared for next release.