### PR TITLE
feat: Support simple selector filter within logical filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tigrisdata/core",
-	"version": "1.0.0-alpha.8",
+	"version": "1.0.0-alpha.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tigrisdata/core",
-			"version": "1.0.0-alpha.8",
+			"version": "1.0.0-alpha.9",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.6.7",
 				"google-protobuf": "^3.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tigrisdata/core",
-	"version": "1.0.0-alpha.8",
+	"version": "1.0.0-alpha.9",
 	"description": "Tigris client for Typescript",
 	"author": "Tigris Data (https://www.tigrisdata.com/)",
 	"contributors": [

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -1,6 +1,7 @@
 import {
 	LogicalFilter,
-	LogicalOperator, Selector,
+	LogicalOperator,
+	Selector,
 	SelectorFilter,
 	SelectorFilterOperator,
 	TigrisCollectionType,
@@ -10,7 +11,7 @@ import {Utility} from '../utility';
 describe('filters tests', () => {
 	it('simpleSelectorFilterTest', () => {
 		const filter1: Selector<IUser> = {
-				name: 'Alice'
+			name: 'Alice'
 		};
 		expect(Utility.filterToString(filter1)).toBe('{"name":"Alice"}');
 
@@ -25,6 +26,35 @@ describe('filters tests', () => {
 		expect(Utility.filterToString(filter3)).toBe('{"isActive":true}');
 
 	});
+
+	it('simplerSelectorWithinLogicalFilterTest', () => {
+		const filter1: LogicalFilter<IUser> = {
+			op: LogicalOperator.AND,
+			selectorFilters: [
+				{
+					name: 'Alice'
+				},
+				{
+					balance: 100
+				}
+			]
+		};
+		expect(Utility.filterToString(filter1)).toBe('{"$and":[{"name":"Alice"},{"balance":100}]}');
+
+		const filter2: LogicalFilter<IUser> = {
+			op: LogicalOperator.OR,
+			selectorFilters: [
+				{
+					name: 'Alice'
+				},
+				{
+					name: 'Emma'
+				}
+			]
+		};
+		expect(Utility.filterToString(filter2)).toBe('{"$or":[{"name":"Alice"},{"name":"Emma"}]}');
+	});
+
 	it('basicSelectorFilterTest', () => {
 		const filter1: SelectorFilter<IUser> = {
 			op: SelectorFilterOperator.EQ,

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,19 +185,6 @@ export class UpdateResponse extends DMLResponse {
 
 }
 
-export class CreateOrUpdateCollectionsResponse extends TigrisResponse {
-	private readonly _message: string;
-
-	constructor(message: string, status: string) {
-		super(status);
-		this._message = message;
-	}
-
-	get message(): string {
-		return this._message;
-	}
-}
-
 export class WriteOptions {}
 
 export class DeleteRequestOptions {}
@@ -293,7 +280,7 @@ export type FieldTypes = string | number | boolean | bigint | BigInteger;
 
 export type LogicalFilter<T> = {
 	op: LogicalOperator;
-	selectorFilters?: Array<SelectorFilter<T>>;
+	selectorFilters?: Array<SelectorFilter<T> | Selector<T>>;
 	logicalFilters?: Array<LogicalFilter<T>>;
 };
 

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -53,7 +53,7 @@ export const Utility = {
 			return filter.fields;
 		}
 		// add support later
-		return {};
+		return filter;
 	},
 
 	_logicalFilterToString<T>(filter: LogicalFilter<T>): string {


### PR DESCRIPTION
 - Support SimpleSelector within logical filter

Usage:

from

```
const logicalFilter: LogicalFilter<IUser> = {
  op: LogicalOperator.OR,
  selectorFilters: [
    {
      op: SelectorFilterOperator.EQ,
      fields: {
        name: 'alice'
      }
    },
    {
      op: SelectorFilterOperator.EQ,
      fields: {
        name: 'emma'
      }
    }
  ]
};
```

to (optionally also support)

```
const logicalFilter: LogicalFilter<IUser> = {
  op: LogicalOperator.OR,
  selectorFilters: [
    {
         name: 'alice'
    },
    {
        name: 'emma'
    }
  ]
};
```

 - Prepare for next release.