### PR TITLE
refactor: Field selection api for search

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -300,12 +300,14 @@ export class Collection<T extends TigrisCollectionType> {
 				));
 		}
 
-		if (request.readFields !== undefined) {
-			searchRequest.setFields(
-				Utility.stringToUint8Array(
-					Utility.readFieldString(request.readFields)
-				));
+		if (request.includeFields !== undefined) {
+			searchRequest.setIncludeFieldsList(request.includeFields);
 		}
+
+		if (request.excludeFields !== undefined) {
+			searchRequest.setIncludeFieldsList(request.excludeFields);
+		}
+
 		if (options !== undefined) {
 			searchRequest.setPage(options.page).setPageSize(options.perPage);
 		}

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -1,13 +1,13 @@
-import {LogicalFilter, ReadFields, Selector, SelectorFilter, TigrisCollectionType} from "../types";
+import {LogicalFilter, Selector, SelectorFilter, TigrisCollectionType} from "../types";
 import {
 	FacetCount as ProtoFacetCount,
 	FacetStats as ProtoFacetStats,
+	Page as ProtoSearchPage,
 	SearchFacet as ProtoSearchFacet,
 	SearchHit as ProtoSearchHit,
 	SearchHitMeta as ProtoSearchHitMeta,
 	SearchMetadata as ProtoSearchMetadata,
-	SearchResponse as ProtoSearchResponse,
-	Page as ProtoSearchPage
+	SearchResponse as ProtoSearchResponse
 } from "../proto/server/v1/api_pb";
 import {Utility} from "../utility";
 
@@ -38,9 +38,13 @@ export type SearchRequest<T extends TigrisCollectionType> = {
 	 */
 	sort?: SortOrder,
 	/**
-	 * Document fields to include/exclude when returning search results
+	 * Document fields to include when returning search results
 	 */
-	readFields?: ReadFields;
+	includeFields?: Array<string>;
+	/**
+	 * Document fields to exclude when returning search results
+	 */
+	excludeFields?: Array<string>;
 };
 
 /**


### PR DESCRIPTION
To create a search request:

```
		const request: SearchRequest<IBook> = {
			q: "philosophy",
			includeFields: ["one", "two"],
			excludeFields: ["three"]
		};
```