### PR TITLE
fix: Do not require insecure config option, fallback to secure channel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tigrisdata/core",
-	"version": "1.0.0-beta.2",
+	"version": "1.0.0-beta.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tigrisdata/core",
-			"version": "1.0.0-beta.2",
+			"version": "1.0.0-beta.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.6.10",

--- a/src/tigris.ts
+++ b/src/tigris.ts
@@ -121,7 +121,7 @@ export class Tigris {
 				grpc.credentials.createSsl()
 			);
 		} else if (
-			(config.insecureChannel === undefined || config.insecureChannel) &&
+			(config.insecureChannel !== undefined || config.insecureChannel) &&
 			config.clientSecret !== undefined
 		) {
 			// auth & insecure channel


### PR DESCRIPTION
Default to secure channel if `insecureChannel` is not explicitly set in config.