### PR TITLE
feat: non-streaming search api with pagination

### DIFF
--- a/src/__tests__/cursor/cursor.spec.ts
+++ b/src/__tests__/cursor/cursor.spec.ts
@@ -1,0 +1,96 @@
+import {Server, ServerCredentials} from "@grpc/grpc-js";
+import TestService, {TestTigrisService} from "../test-service";
+import {TigrisService} from "../../proto/server/v1/api_grpc_pb";
+import {IBook} from "../tigris.rpc.spec";
+import {Tigris} from "../../tigris";
+import {TigrisCursorInUseError} from "../../error";
+import {ObservabilityService} from "../../proto/server/v1/observability_grpc_pb";
+import TestObservabilityService from "../test-observability-service";
+import {ReadResponse} from "../../proto/server/v1/api_pb";
+import {DB} from "../../db";
+
+describe("class FindCursor", () => {
+	let server: Server;
+	const SERVER_PORT = 5003;
+	let db: DB;
+
+	beforeAll((done) => {
+		server = new Server();
+		TestTigrisService.reset();
+		server.addService(TigrisService, TestService.handler.impl);
+		server.addService(ObservabilityService, TestObservabilityService.handler.impl);
+		server.bindAsync(
+			"0.0.0.0:" + SERVER_PORT,
+			// test purpose only
+			ServerCredentials.createInsecure(),
+			(err: Error | null) => {
+				if (err) {
+					console.log(err);
+				} else {
+					server.start();
+				}
+			}
+		);
+		const tigris = new Tigris({serverUrl: "0.0.0.0:" + SERVER_PORT, insecureChannel: true});
+		db = tigris.getDatabase("db3");
+		done();
+	});
+
+	beforeEach(() => {
+		TestTigrisService.reset();
+	});
+
+	afterAll((done) => {
+		server.forceShutdown();
+		done();
+	});
+
+	it("returns iterable stream as it is", async () => {
+		const cursor = db.getCollection<IBook>("books").findMany();
+		let bookCounter = 0;
+		for await (const book of cursor) {
+			expect(book.id).toBeDefined();
+			bookCounter++;
+		}
+		expect(bookCounter).toBeGreaterThan(0);
+	})
+
+	it("Pipes the stream as iterable", async () => {
+		const cursor = db.getCollection<IBook>("books").findMany();
+		let bookCounter = 0;
+		for await (const book of cursor.stream()) {
+			expect(book.id).toBeDefined();
+			bookCounter++;
+		}
+		expect(bookCounter).toBeGreaterThan(0);
+	})
+
+	it("returns stream as an array", () => {
+		const cursor = db.getCollection<IBook>("books").findMany();
+		const booksPromise = cursor.toArray();
+		booksPromise.then(books => expect(books.length).toBeGreaterThan(0));
+
+		return booksPromise;
+	})
+
+	it("does not allow cursor to be re-used", () => {
+		const cursor = db.getCollection<IBook>("books").findMany();
+		// cursor.stream() is a generator fn, calling next() would retrieve item from stream
+		cursor.stream().next();
+		expect(() => cursor.toArray()).toThrow(TigrisCursorInUseError);
+	})
+
+	it("allows cursor to be re-used once reset", async () => {
+		const cursor = db.getCollection<IBook>("books").findMany();
+
+		let bookCounter = 0;
+		for await (const book of cursor.stream()) {
+			expect(book.id).toBeDefined();
+			bookCounter++;
+		}
+
+		cursor.reset()
+		const books = await cursor.toArray();
+		expect(books.length).toBe(bookCounter);
+	})
+});

--- a/src/cursor/abstract-cursor.ts
+++ b/src/cursor/abstract-cursor.ts
@@ -1,0 +1,121 @@
+import * as proto from "google-protobuf";
+import { ClientReadableStream } from "@grpc/grpc-js";
+import { TigrisCursorInUseError } from "../error";
+
+/** @internal */
+export interface Initializer<TResp extends proto.Message> {
+	init(): ClientReadableStream<TResp>;
+}
+
+/** @internal */
+const tStream = Symbol("stream");
+/** @internal */
+const tReady = Symbol("ready");
+/** @internal */
+const tClosed = Symbol("closed");
+
+export abstract class AbstractCursor<T, TResp extends proto.Message> {
+	/** @internal */
+	[tStream]: ClientReadableStream<TResp>;
+	/** @internal */
+	[tReady]: boolean;
+	/** @internal */
+	[tClosed]: boolean;
+	/** @internal */
+	private _initializer: Initializer<TResp>;
+
+	/** @internal */
+	protected constructor(initializer: Initializer<TResp>) {
+		this._initializer = initializer;
+		this[tReady] = false;
+		this._initialize();
+		this[tClosed] = false;
+	}
+
+	/** @internal */
+	private _assertNotInUse() {
+		if (this[tClosed]) {
+			throw new TigrisCursorInUseError();
+		}
+		this[tClosed] = true;
+	}
+
+	/**
+	 * Returns a stream of documents to iterate on
+	 *
+	 * Usage:
+	 * const cursor = myCollection.find();
+	 * for await (const doc of cursor.stream()) {
+	 *     console.log(doc);
+	 * }
+	 *
+	 * @throws {@link TigrisCursorInUseError} - if cursor is being consumed or has been consumed.
+	 * @see {@link reset()} to re-use a cursor.
+	 */
+	async *stream(): AsyncIterableIterator<T> {
+		this._assertNotInUse();
+		for await (const message of this[tStream]) {
+			yield this._transform(message);
+		}
+		return;
+	}
+
+	/**
+	 * Returns an async iterator to iterate on documents
+	 *
+	 * Usage:
+	 * const cursor = myCollection.find();
+	 * for await (const doc of cursor) {
+	 *     console.log(doc);
+	 * }
+	 *
+	 * @throws {@link TigrisCursorInUseError} - if cursor is being consumed or has been consumed.
+	 * @see {@link reset()} to re-use a cursor.
+	 */
+	[Symbol.asyncIterator](): AsyncIterableIterator<T> {
+		return this.stream()[Symbol.asyncIterator]();
+	}
+
+	/**
+	 * Returns an array of documents. The caller is responsible for making sure that there
+	 * is enough memory to store the results.
+	 *
+	 * @throws {@link TigrisCursorInUseError} - if cursor is being consumed or has been consumed.
+	 * @see {@link reset()} to re-use a cursor.
+	 */
+	toArray(): Promise<Array<T>> {
+		this._assertNotInUse();
+		const buffer = new Array<T>();
+
+		return new Promise<Array<T>>((resolve, reject) => {
+			this[tStream].on("data", (message: TResp) => {
+				buffer.push(this._transform(message));
+			});
+			this[tStream].on("error", reject);
+			this[tStream].on("end", () => resolve(buffer));
+		});
+	}
+
+	/** Converts a message from stream to user consumable object */
+	protected abstract _transform(message: TResp): T;
+
+	/** @internal */
+	private _initialize(): void {
+		if (!this[tReady]) {
+			this[tStream] = this._initializer.init();
+			this[tReady] = true;
+		}
+	}
+
+	/**
+	 * This essentially sends a new query to server and allows the cursor to be re-used. A new
+	 * query to server is sent even if this cursor is not yet consumed.
+	 *
+	 * Note: A cursor may yield different results after reset()
+	 */
+	reset(): void {
+		this[tClosed] = false;
+		this[tReady] = false;
+		this._initialize();
+	}
+}

--- a/src/cursor/cursor.ts
+++ b/src/cursor/cursor.ts
@@ -1,0 +1,42 @@
+import { AbstractCursor, Initializer } from "./abstract-cursor";
+import { ReadRequest, ReadResponse } from "../proto/server/v1/api_pb";
+import { TigrisClient } from "../proto/server/v1/api_grpc_pb";
+import { Session } from "../session";
+import { Utility } from "../utility";
+import { ClientReadableStream } from "@grpc/grpc-js";
+import { TigrisClientConfig } from "../tigris";
+
+/** @internal */
+export class ReadCursorInitializer implements Initializer<ReadResponse> {
+	private readonly _client: TigrisClient;
+	private readonly _request: ReadRequest;
+	private readonly _session: Session;
+
+	constructor(client: TigrisClient, request: ReadRequest, tx: Session) {
+		this._client = client;
+		this._request = request;
+		this._session = tx;
+	}
+
+	init(): ClientReadableStream<ReadResponse> {
+		return this._client.read(this._request, Utility.txToMetadata(this._session));
+	}
+}
+
+/**
+ * Cursor to supplement find() queries
+ */
+export class Cursor<T> extends AbstractCursor<T, ReadResponse> {
+	/** @internal */
+	private readonly _config: TigrisClientConfig;
+
+	constructor(initializer: ReadCursorInitializer, config: TigrisClientConfig) {
+		super(initializer);
+		this._config = config;
+	}
+
+	/** @override */
+	_transform(message: ReadResponse): T {
+		return Utility.jsonStringToObj<T>(Utility._base64Decode(message.getData_asB64()), this._config);
+	}
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,29 @@
+/**
+ * Generic TigrisError
+ */
+export class TigrisError extends Error {
+	constructor(message: string) {
+		super(message);
+	}
+
+	override get name(): string {
+		return "TigrisError";
+	}
+}
+
+/**
+ * An error thrown when the user attempts to consume a cursor that has already been
+ * used
+ *
+ * @public
+ * @category Error
+ */
+export class TigrisCursorInUseError extends TigrisError {
+	constructor(message = "Cursor is already in use or used. Please reset()") {
+		super(message);
+	}
+
+	override get name(): string {
+		return "TigrisCursorInUseError";
+	}
+}


### PR DESCRIPTION
Removing callbacks for streaming APIs and instead using iteration to read results. For ex:

```typescript
		const booksIterator = db1.getCollection<IBook>("books").findMany();
		for await (const book of booksIterator) {
			bookCounter++;
			expect(book.author).toBe("Marcel Proust");
		}
		expect(bookCounter).toBe(4);
```

> This would be a breaking API change and require changes across the usages