### PR TITLE
refactor: Updates for collections API

### DIFF
--- a/src/__tests__/cursor/cursor.spec.ts
+++ b/src/__tests__/cursor/cursor.spec.ts
@@ -6,7 +6,6 @@ import {Tigris} from "../../tigris";
 import {TigrisCursorInUseError} from "../../error";
 import {ObservabilityService} from "../../proto/server/v1/observability_grpc_pb";
 import TestObservabilityService from "../test-observability-service";
-import {ReadResponse} from "../../proto/server/v1/api_pb";
 import {DB} from "../../db";
 
 describe("class FindCursor", () => {
@@ -75,8 +74,8 @@ describe("class FindCursor", () => {
 
 	it("does not allow cursor to be re-used", () => {
 		const cursor = db.getCollection<IBook>("books").findMany();
-		// cursor.stream() is a generator fn, calling next() would retrieve item from stream
-		cursor.stream().next();
+		// cursor is backed by is a generator fn, calling next() would retrieve item from stream
+		cursor[Symbol.asyncIterator]().next();
 		expect(() => cursor.toArray()).toThrow(TigrisCursorInUseError);
 	})
 

--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -167,7 +167,7 @@ describe("rpc tests", () => {
 	it("insert", () => {
 		const tigris = new Tigris({serverUrl: "0.0.0.0:" + SERVER_PORT, insecureChannel: true});
 		const db1 = tigris.getDatabase("db3");
-		const insertionPromise = db1.getCollection<IBook>("books").insert({
+		const insertionPromise = db1.getCollection<IBook>("books").insertOne({
 			author: "author name",
 			id: 0,
 			tags: ["science"],
@@ -182,7 +182,7 @@ describe("rpc tests", () => {
 	it("insert2", () => {
 		const tigris = new Tigris({serverUrl: "0.0.0.0:" + SERVER_PORT, insecureChannel: true});
 		const db1 = tigris.getDatabase("db3");
-		const insertionPromise = db1.getCollection<IBook2>("books").insert({
+		const insertionPromise = db1.getCollection<IBook2>("books").insertOne({
 			id: 0,
 			title: "science book",
 			metadata: {
@@ -202,7 +202,7 @@ describe("rpc tests", () => {
 		const randomNumber: number = Math.floor(Math.random() * 100);
 		// pass the random number in author field. mock server reads author and sets as the
 		// primaryKey field.
-		const insertionPromise = db1.getCollection<IBook1>("books-with-optional-field").insert({
+		const insertionPromise = db1.getCollection<IBook1>("books-with-optional-field").insertOne({
 			author: "" + randomNumber,
 			tags: ["science"],
 			title: "science book"
@@ -216,7 +216,7 @@ describe("rpc tests", () => {
 	it("insertOrReplace", () => {
 		const tigris = new Tigris({serverUrl: "0.0.0.0:" + SERVER_PORT, insecureChannel: true});
 		const db1 = tigris.getDatabase("db3");
-		const insertOrReplacePromise = db1.getCollection<IBook>("books").insertOrReplace({
+		const insertOrReplacePromise = db1.getCollection<IBook>("books").insertOrReplaceOne({
 			author: "author name",
 			id: 0,
 			tags: ["science"],
@@ -234,7 +234,7 @@ describe("rpc tests", () => {
 		const randomNumber: number = Math.floor(Math.random() * 100);
 		// pass the random number in author field. mock server reads author and sets as the
 		// primaryKey field.
-		const insertOrReplacePromise = db1.getCollection<IBook1>("books-with-optional-field").insertOrReplace({
+		const insertOrReplacePromise = db1.getCollection<IBook1>("books-with-optional-field").insertOrReplaceOne({
 			author: "" + randomNumber,
 			tags: ["science"],
 			title: "science book"
@@ -285,7 +285,7 @@ describe("rpc tests", () => {
 	it("readOne", () => {
 		const tigris = new Tigris({serverUrl: "0.0.0.0:" + SERVER_PORT, insecureChannel: true});
 		const db1 = tigris.getDatabase("db3");
-		const readOnePromise = db1.getCollection<IBook>("books").findOne({
+		const readOnePromise = db1.getCollection<IBook>("books").findOne( {
 			op: SelectorFilterOperator.EQ,
 			fields: {
 				id: 1
@@ -499,7 +499,7 @@ describe("rpc tests", () => {
 		const txDB = tigris.getDatabase("test-tx");
 		const books = txDB.getCollection<IBook>("books");
 		txDB.transact(tx => {
-			books.insert(
+			books.insertOne(
 				{
 					id: 1,
 					author: "Alice",
@@ -513,7 +513,7 @@ describe("rpc tests", () => {
 					fields: {
 						id: 1
 					}
-				}, tx).then(() => {
+				}, undefined, tx).then(() => {
 					books.update({
 							op: SelectorFilterOperator.EQ,
 							fields: {

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -10,7 +10,6 @@ import {
 	SearchRequestOptions,
 	SortOrder
 } from "../search/types";
-import {Collation} from "../proto/server/v1/api_pb";
 
 describe("utility tests", () => {
 	it("base64encode", () => {

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -1,4 +1,4 @@
-import { LogicalFilter, Selector, SelectorFilter, TigrisCollectionType } from "../types";
+import { Filter, TigrisCollectionType } from "../types";
 import {
 	FacetCount as ProtoFacetCount,
 	FacetStats as ProtoFacetStats,
@@ -29,7 +29,7 @@ export type SearchRequest<T extends TigrisCollectionType> = {
 	/**
 	 * Filter to further refine the search results
 	 */
-	filter?: SelectorFilter<T> | LogicalFilter<T> | Selector<T>;
+	filter?: Filter<T>;
 	/**
 	 * Facet fields to categorically arrange indexed terms
 	 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,7 +189,37 @@ export class UpdateResponse extends DMLResponse {
 
 export class WriteOptions {}
 
-export class DeleteRequestOptions {}
+export class DeleteRequestOptions {
+	private _collation: Collation;
+
+	constructor(collation: Collation) {
+		this._collation = collation;
+	}
+
+	get collation(): Collation {
+		return this._collation;
+	}
+
+	set collation(value: Collation) {
+		this._collation = value;
+	}
+}
+
+export class UpdateRequestOptions {
+	private _collation: Collation;
+
+	constructor(collation: Collation) {
+		this._collation = collation;
+	}
+
+	get collation(): Collation {
+		return this._collation;
+	}
+
+	set collation(value: Collation) {
+		this._collation = value;
+	}
+}
 
 export class ReadRequestOptions {
 	static DEFAULT_LIMIT = 100;
@@ -243,11 +273,7 @@ export class ReadRequestOptions {
 	}
 }
 
-export class UpdateRequestOptions {}
-
 export class TransactionOptions {}
-
-export class EventsRequestOptions {}
 
 export class StreamEvent<T> {
 	private readonly _txId: string;
@@ -303,8 +329,6 @@ export class TransactionResponse extends TigrisResponse {
 	}
 }
 
-export class InsertOptions {}
-
 export class PublishOptions {
 	private _partition: number;
 
@@ -336,8 +360,6 @@ export class SubscribeOptions {
 		this._partitions = value;
 	}
 }
-
-export class InsertOrReplaceOptions {}
 
 export class ServerMetadata {
 	private readonly _serverVersion: string;
@@ -494,3 +516,5 @@ export type SelectorFilter<T> = Partial<{
 	op?: SelectorFilterOperator;
 	fields: Selector<T>;
 }>;
+
+export type Filter<T> = SelectorFilter<T> | LogicalFilter<T> | Selector<T>;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -4,6 +4,7 @@ import { Session } from "./session";
 
 import {
 	CollectionType,
+	DeleteRequestOptions,
 	LogicalFilter,
 	LogicalOperator,
 	ReadFields,
@@ -17,6 +18,7 @@ import {
 	TigrisSchema,
 	UpdateFields,
 	UpdateFieldsOperator,
+	UpdateRequestOptions,
 } from "./types";
 import * as fs from "node:fs";
 import {
@@ -31,8 +33,10 @@ import {
 } from "./search/types";
 import {
 	Collation as ProtoCollation,
+	DeleteRequestOptions as ProtoDeleteRequestOptions,
 	ReadRequestOptions as ProtoReadRequestOptions,
 	SearchRequest as ProtoSearchRequest,
+	UpdateRequestOptions as ProtoUpdateRequestOptions,
 } from "./proto/server/v1/api_pb";
 import { TigrisClientConfig } from "./tigris";
 
@@ -331,6 +335,24 @@ export const Utility = {
 			if (input.offset !== undefined) {
 				result.setOffset(Utility.stringToUint8Array(input.offset));
 			}
+		}
+		return result;
+	},
+	_deleteRequestOptionsToProtoDeleteRequestOptions(
+		input: DeleteRequestOptions
+	): ProtoDeleteRequestOptions {
+		const result: ProtoDeleteRequestOptions = new ProtoDeleteRequestOptions();
+		if (input !== undefined && input.collation !== undefined) {
+			result.setCollation(new ProtoCollation().setCase(input.collation.case));
+		}
+		return result;
+	},
+	_updateRequestOptionsToProtoUpdateRequestOptions(
+		input: UpdateRequestOptions
+	): ProtoUpdateRequestOptions {
+		const result: ProtoUpdateRequestOptions = new ProtoUpdateRequestOptions();
+		if (input !== undefined && input.collation !== undefined) {
+			result.setCollation(new ProtoCollation().setCase(input.collation.case));
 		}
 		return result;
 	},


### PR DESCRIPTION
- Transform read cursor to native [Node.js readable streams](https://nodejs.org/api/stream.html#class-streamreadable)
- Rename `insert` to `insertOne`, to have consistent apis:
    - `insertOne`, `insertMany`, `findOne`, `findMany`
- Allow `collation` option for update and delete queries.
- Code documentation on collection APIs 
    