### PR TITLE
feat: Add default metadata for secure channels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tigrisdata/core",
-	"version": "1.0.0-beta.6",
+	"version": "1.0.0-beta.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tigrisdata/core",
-			"version": "1.0.0-beta.6",
+			"version": "1.0.0-beta.7",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.6.10",


### PR DESCRIPTION
For secure channels add the default metadata for every outbound calls.