### PR TITLE
refactor: Fixed typescript warnings

### DIFF
--- a/src/consumables/utils.ts
+++ b/src/consumables/utils.ts
@@ -3,7 +3,7 @@ import { Readable } from "node:stream";
 
 function _next<T, TResp>(
 	stream: ClientReadableStream<TResp>,
-	transform: (TResp) => T
+	transform: (arg: TResp) => T
 ): AsyncIterableIterator<T> {
 	const iter: () => AsyncIterableIterator<T> = async function* () {
 		for await (const message of stream) {
@@ -18,7 +18,7 @@ function _next<T, TResp>(
 // Utility to convert grpc response streams to Readable streams
 export function clientReadableToStream<T, TResp>(
 	stream: ClientReadableStream<TResp>,
-	transform: (TResp) => T
+	transform: (arg: TResp) => T
 ): Readable {
 	return Readable.from(_next(stream, transform));
 }

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -270,7 +270,7 @@ export class Topic<T extends TigrisTopicType> extends ReadOnlyCollection<T> {
 			);
 		}
 
-		const transform: (ProtoSubscribeResponse) => T = (resp: ProtoSubscribeResponse) => {
+		const transform: (arg: ProtoSubscribeResponse) => T = (resp: ProtoSubscribeResponse) => {
 			return Utility.jsonStringToObj<T>(
 				Utility._base64Decode(resp.getMessage_asB64()),
 				this.config


### PR DESCRIPTION
Fixing following warnings from lgtm.com to gain back `A+`

- The parameter 'ProtoSubscribeResponse' has type 'any', but its name coincides with the imported type ProtoSubscribeResponse.
- The parameter 'TResp' has type 'any', but its name coincides with the type parameter TResp.

Updated api submodule.
