### PR TITLE
fix: Load env variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.6.10",
+				"dotenv": "^16.0.3",
 				"google-protobuf": "^3.21.0",
 				"json-bigint": "^1.0.0",
 				"typescript": "^4.7.2"
@@ -26,7 +27,7 @@
 				"eslint-plugin-unicorn": "^43.0.2",
 				"eslint-plugin-unused-imports": "^2.0.0",
 				"grpc_tools_node_protoc_ts": "^5.3.2",
-				"grpc-tools": "^1.11.2",
+				"grpc-tools": "^1.11.3",
 				"jest": "^28.1.3",
 				"prettier": "2.7.1",
 				"ts-jest": "^28.0.8",
@@ -3269,6 +3270,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/dotenv": {
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+			"integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -4267,9 +4276,9 @@
 			"dev": true
 		},
 		"node_modules/grpc-tools": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.2.tgz",
-			"integrity": "sha512-4+EgpnnkJraamY++oyBCw5Hp9huRYfgakjNVKbiE3PgO9Tv5ydVlRo7ZyGJ0C0SEiA7HhbVc1sNNtIyK7FiEtg==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.3.tgz",
+			"integrity": "sha512-cRSK2uhDKHtZ9hLRM35HxaMAMxyh/L7C96Ojt58DhQBdwTOQlV1VIJHSK6X/pDeSQKhaQqWMFfebt8tIcvRfjQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -13893,6 +13902,11 @@
 				"is-obj": "^2.0.0"
 			}
 		},
+		"dotenv": {
+			"version": "16.0.3",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+			"integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+		},
 		"duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -14657,9 +14671,9 @@
 			}
 		},
 		"grpc-tools": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.2.tgz",
-			"integrity": "sha512-4+EgpnnkJraamY++oyBCw5Hp9huRYfgakjNVKbiE3PgO9Tv5ydVlRo7ZyGJ0C0SEiA7HhbVc1sNNtIyK7FiEtg==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.3.tgz",
+			"integrity": "sha512-cRSK2uhDKHtZ9hLRM35HxaMAMxyh/L7C96Ojt58DhQBdwTOQlV1VIJHSK6X/pDeSQKhaQqWMFfebt8tIcvRfjQ==",
 			"dev": true,
 			"requires": {
 				"@mapbox/node-pre-gyp": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"eslint-plugin-unicorn": "^43.0.2",
 		"eslint-plugin-unused-imports": "^2.0.0",
 		"grpc_tools_node_protoc_ts": "^5.3.2",
-		"grpc-tools": "^1.11.2",
+		"grpc-tools": "^1.11.3",
 		"jest": "^28.1.3",
 		"prettier": "2.7.1",
 		"ts-jest": "^28.0.8",
@@ -106,6 +106,7 @@
 	},
 	"dependencies": {
 		"@grpc/grpc-js": "^1.6.10",
+		"dotenv": "^16.0.3",
 		"google-protobuf": "^3.21.0",
 		"json-bigint": "^1.0.0",
 		"typescript": "^4.7.2"

--- a/src/tigris.ts
+++ b/src/tigris.ts
@@ -11,6 +11,8 @@ import {
 } from "./proto/server/v1/api_pb";
 import { GetInfoRequest as ProtoGetInfoRequest } from "./proto/server/v1/observability_pb";
 
+import * as dotenv from "dotenv";
+
 import {
 	DatabaseInfo,
 	DatabaseMetadata,
@@ -119,13 +121,14 @@ const DEST_NAME_KEY = "destination-name";
 export class Tigris {
 	private readonly grpcClient: TigrisClient;
 	private readonly observabilityClient: ObservabilityClient;
-	private readonly config: TigrisClientConfig;
+	private readonly _config: TigrisClientConfig;
 
 	/**
 	 *
 	 * @param  {TigrisClientConfig} config configuration
 	 */
 	constructor(config?: TigrisClientConfig) {
+		dotenv.config();
 		if (typeof config === "undefined") {
 			config = {};
 		}
@@ -158,7 +161,7 @@ export class Tigris {
 			config.serverUrl = config.serverUrl + ":" + DEFAULT_GRPC_PORT;
 		}
 
-		this.config = config;
+		this._config = config;
 		const defaultMetadata: Metadata = new Metadata();
 		defaultMetadata.set(USER_AGENT_KEY, USER_AGENT_VAL);
 		defaultMetadata.set(DEST_NAME_KEY, config.serverUrl);
@@ -171,11 +174,9 @@ export class Tigris {
 			config.clientSecret === undefined
 		) {
 			// no auth - generate insecure channel
-			this.grpcClient = new TigrisClient(config.serverUrl, grpc.credentials.createInsecure());
-			this.observabilityClient = new ObservabilityClient(
-				config.serverUrl,
-				grpc.credentials.createInsecure()
-			);
+			const insecureCreds: ChannelCredentials = grpc.credentials.createInsecure();
+			this.grpcClient = new TigrisClient(config.serverUrl, insecureCreds);
+			this.observabilityClient = new ObservabilityClient(config.serverUrl, insecureCreds);
 		} else if (config.clientId === undefined || config.clientSecret === undefined) {
 			throw new Error("Both `clientId` and `clientSecret` are required");
 		} else {
@@ -235,7 +236,7 @@ export class Tigris {
 					if (error && error.code != status.ALREADY_EXISTS) {
 						reject(error);
 					} else {
-						resolve(new DB(db, this.grpcClient, this.config));
+						resolve(new DB(db, this.grpcClient, this._config));
 					}
 				}
 			);
@@ -259,7 +260,7 @@ export class Tigris {
 	}
 
 	public getDatabase(db: string): DB {
-		return new DB(db, this.grpcClient, this.config);
+		return new DB(db, this.grpcClient, this._config);
 	}
 
 	public getServerMetadata(): Promise<ServerMetadata> {


### PR DESCRIPTION
- Tigris config supports reading env variables, This PR takes care of loading env variables and not rely on app to take care of it. 
- Upgrade grpc-tools version.
- Upgrade API submodule.