### PR TITLE
feat introduces rxjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"dotenv": "^16.0.3",
 				"google-protobuf": "^3.21.0",
 				"json-bigint": "^1.0.0",
+				"rxjs": "^7.5.7",
 				"typescript": "^4.7.2"
 			},
 			"devDependencies": {
@@ -10225,6 +10226,19 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/rxjs": {
+			"version": "7.5.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+			"integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/rxjs/node_modules/tslib": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -19012,6 +19026,21 @@
 			"dev": true,
 			"requires": {
 				"queue-microtask": "^1.2.2"
+			}
+		},
+		"rxjs": {
+			"version": "7.5.7",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+			"integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+			"requires": {
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+					"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+				}
 			}
 		},
 		"safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
 		"dotenv": "^16.0.3",
 		"google-protobuf": "^3.21.0",
 		"json-bigint": "^1.0.0",
+		"rxjs": "^7.5.7",
 		"typescript": "^4.7.2"
 	}
 }


### PR DESCRIPTION
This PR introduces RxJS in the project. It also implements Observers for Collections.events method. It keeps the methods backward compatible.

```
import { debounceTime, filter, map, skip, tap } from "rxjs";
import { Tigris } from "./tigris";

async function init() {
	const tigris = new Tigris();
	const db = await tigris.createDatabaseIfNotExists("test");
	const users = db.getCollection<string>("users");

	// Callback approach
	users.events({
		onNext: console.log,
		onError: console.log,
		onEnd: console.log,
	});

	// RxJS approach
	users
		.events()
		.pipe(
			debounceTime(500), //stream is too frequent and causes flicker on screen, lets debounce a little
			skip(1), // first item in the stream is useless, let's skip it
			filter(event => event.op === 'something'), // filter out the stream that's op !== something
			map(event => event.data), // we only need data from key from stream
			tap(console.log), // console.log the stream, debugging purpose only
		).subscribe();
}
```