### PR TITLE
chore: Publish beta releases to @latest tag temporarily

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,8 @@ jobs:
           npm install --no-package-lock --no-save \
               @semantic-release/commit-analyzer \
               @semantic-release/release-notes-generator \
-              @semantic-release/github
+              @semantic-release/github \
+              @semantic-release/exec
       - name: Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,14 @@
 			"@semantic-release/commit-analyzer",
 			"@semantic-release/release-notes-generator",
 			"@semantic-release/npm",
-			"@semantic-release/github"
+			"@semantic-release/github",
+			[
+				"@semantic-release/exec",
+				{
+					"verifyConditionsCmd": "./scripts/verifyReleaseNeeded.sh ${nextRelease.version}",
+					"publishCmd": "./scripts/publishLatestRelease.sh ${nextRelease.version}"
+				}
+			]
 		]
 	},
 	"repository": {
@@ -73,9 +80,7 @@
 		"prepare": "npm run update_api && npm run protoc && npm run tsc",
 		"prepublishOnly": "npm test && npm run lint",
 		"prettify": "npx prettier --write .",
-		"preversion": "npm run lint",
-		"version": "git add -A src",
-		"postversion": "git push && git push --tags"
+		"preversion": "npm run lint"
 	},
 	"engines": {
 		"node": ">= 12.0.0"

--- a/scripts/publishLatestRelease.sh
+++ b/scripts/publishLatestRelease.sh
@@ -11,7 +11,7 @@ fi
 
 NEXT=$1
 echo "Setting version in package.json to: $NEXT"
-VERSION_OUT=$(npm version $NEXT --no-git-tag-version | tail -n1)
+VERSION_OUT=$(npm version $NEXT --no-git-tag-version --allow-same-version | tail -n1)
 
 echo "npm version out: $VERSION_OUT"
 

--- a/scripts/publishLatestRelease.sh
+++ b/scripts/publishLatestRelease.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Temporary script to publish beta releases to @latest dist-tag. This should be removed
+# once first stable release is published to @latest dist-tag
+
+# Attempt to publish a new release to @latest tag
+if [[ -z "$1" ]] ; then
+    echo 'No argument specified. Exiting...'
+    exit 1
+fi
+
+NEXT=$1
+echo "Setting version in package.json to: $NEXT"
+VERSION_OUT=$(npm version $NEXT --no-git-tag-version | tail -n1)
+
+echo "npm version out: $VERSION_OUT"
+
+if [[ "$VERSION_OUT" != *"$NEXT"* ]]; then
+	echo 'Failed to set npm version. Exiting....'
+	exit 1
+fi
+
+echo "Ready to publish $NEXT to dist-tag: @latest"
+npm publish
+
+exit 0

--- a/scripts/verifyReleaseNeeded.sh
+++ b/scripts/verifyReleaseNeeded.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Temporary script to publish beta releases to @latest dist-tag. This should be removed
+# once first stable release is published to @latest dist-tag.
+
+# Determine if version @latest dist-tag is behind $1 or not
+if [[ -z "$1" ]] ; then
+    echo 'No argument specified, no release needed. Exiting...'
+    exit 1
+fi
+
+NEXT=$1
+echo "Next release version: $NEXT"
+
+if [[ "$NEXT" != *"beta"* ]]; then
+	echo 'Argument is not a valid beta release. Exiting...'
+	exit 1
+fi
+
+NPM_LATEST=$(npm view @tigrisdata/core dist-tags.latest)
+echo "npm @latest version is: $NPM_LATEST"
+
+if [[ "$NPM_LATEST" != *"beta"* ]]; then
+	echo 'Stable release already published to @latest dist-tag'
+	echo 'These temporary steps can be cleaned up and not needed anymore. Exiting...'
+	exit 1
+fi
+
+if [[ "$NPM_LATEST" == "$NEXT" ]]; then
+	echo "@latest is already on $NEXT"
+	echo 'No release needed. Exiting...'
+	exit 1
+fi
+
+echo 'Release needed on @latest dist-tag'
+exit 0


### PR DESCRIPTION
Current releases are only getting published to `beta` tag. Added a step after a release gets published to `beta` it should also gets published to `latest` tag. This is temporary until we have our first stable release and can be removed then.

The script should fail publishing to `latest` if there is already a stable release.