### PR TITLE
feat: Use different database name for preview deployments

### DIFF
--- a/src/__tests__/utils/manifest-loader.spec.ts
+++ b/src/__tests__/utils/manifest-loader.spec.ts
@@ -1,8 +1,17 @@
-import { canBeSchema, loadTigrisManifest, TigrisManifest } from "../../utils/manifest-loader";
+import {
+	canBeSchema, getProps,
+	loadTigrisManifest,
+	nerfGitBranchName,
+	TigrisManifest
+} from "../../utils/manifest-loader";
 import { TigrisDataTypes } from "../../types";
 import { TigrisFileNotFoundError, TigrisMoreThanOneSchemaDefined } from "../../error";
 
 describe("Manifest loader", () => {
+	const env = Object.assign({}, process.env);
+	afterEach(() => {
+		process.env = env;
+	});
 
 	it("generates manifest from file system", () => {
 		const schemaPath = process.cwd() + "/src/__tests__/data/models";
@@ -22,7 +31,8 @@ describe("Manifest loader", () => {
 				"schemaName": "ProductSchema"
 			}]
 		},
-			{	"dbName": "embedded",
+			{
+				"dbName": "embedded",
 				"collections": [{
 					"collectionName": "users",
 					"schemaName": "userSchema",
@@ -50,9 +60,10 @@ describe("Manifest loader", () => {
 						"updated": { "type": "date-time" },
 						"user_id": { "type": "string", "primary_key": { "order": 1 } }
 					}
-				}]},
-			{ "dbName": "empty", "collections": [] },
-			];
+				}]
+			},
+			{ "dbName": "empty", "collections": [] }
+		];
 		expect(manifest).toStrictEqual(expected);
 	});
 
@@ -113,6 +124,90 @@ describe("Manifest loader", () => {
 		"identifies invalid schema definition %p",
 		(definition) => {
 			expect(canBeSchema(definition)).toBeFalsy();
+		}
+	);
+
+	type envProps = {
+		context?: string,
+		head?: string,
+		vercel_env?: string,
+		vercel_git_commit_ref: string
+	}
+
+	const propsTestCases = [
+		{
+			testName: "branch-deploy netlify preview env",
+			envVars: {
+				context: "branch-deploy",
+				head: "hotfix/123"
+			},
+			expected: { dbNameSuffix: "_preview_hotfix_123_d7b15e9d" }
+		},
+		{
+			testName: "deploy-preview netlify preview env",
+			envVars: {
+				context: "deploy-preview",
+				head: "hotfix/123"
+			},
+			expected: { dbNameSuffix: "_preview_hotfix_123_d7b15e9d" }
+		},
+		{
+			testName: "valid vercel preview env",
+			envVars: {
+				vercel_env: "preview",
+				vercel_git_commit_ref: "hotfix/123"
+			},
+			expected: { dbNameSuffix: "_preview_hotfix_123_d7b15e9d" }
+		},
+		{
+			testName: "netlify env missing git branch",
+			envVars: {
+				context: "branch-deploy"
+			},
+			expected: { dbNameSuffix: "" }
+		},
+		{
+			testName: "vercel env empty git branch",
+			envVars: {
+				vercel_env: "preview",
+				vercel_git_commit_ref: ""
+			},
+			expected: { dbNameSuffix: "" }
+		},
+		{
+			testName: "No deploy env",
+			envVars: {},
+			expected: { dbNameSuffix: "" }
+		},
+	];
+
+	test.each(propsTestCases)(
+		'getProps() for $testName',
+		({ testName, envVars, expected }) => {
+			process.env.CONTEXT = envVars.context;
+			process.env.HEAD = envVars.head;
+			process.env.VERCEL_ENV = envVars.vercel_env;
+			process.env.VERCEL_GIT_COMMIT_REF = envVars.vercel_git_commit_ref;
+			expect(getProps()).toStrictEqual(expected);
+		}
+	);
+
+	const nerfingTestCases = [
+		["main/fork", "main_fork_6e3e0518"],
+		["main-fork", "main_fork_56276341"],
+		["main?fork", "main_fork_c7873468"],
+		["sTaging21", "sTaging21_a9877c4a"],
+		["hotfix/jira-23$4", "hotfix_jira_23_4_ddabe4ab"],
+		["", "_e3b0c442"],
+		["release", "release_a4d451ec"],
+		["zero ops", "zero_ops_c42af5f1"],
+		["under_score", "under_score_d8071166"]
+	];
+
+	test.each(nerfingTestCases)(
+		"nerfs the name %p",
+		(original, nerfed) => {
+			expect(nerfGitBranchName(original)).toBe(nerfed);
 		}
 	);
 });


### PR DESCRIPTION
- Detect if the site is being deployed to a Vercel/Netlify preview environment and append a suffix `_preview_{uniq identifier for vcs branch}` to the database name.