### PR TITLE
fix: Using latest channel for beta releases

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -25,8 +25,7 @@ jobs:
           npm install --no-package-lock --no-save \
               @semantic-release/commit-analyzer \
               @semantic-release/release-notes-generator \
-              @semantic-release/github \
-              @semantic-release/exec
+              @semantic-release/github
       - name: Release dry run
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,8 +43,7 @@ jobs:
           npm install --no-package-lock --no-save \
               @semantic-release/commit-analyzer \
               @semantic-release/release-notes-generator \
-              @semantic-release/github \
-              @semantic-release/exec
+              @semantic-release/github
       - name: Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -36,28 +36,23 @@
 	"release": {
 		"branches": [
 			{
+				"name": "release"
+			},
+			{
 				"name": "beta",
-				"prerelease": true
+				"prerelease": true,
+				"channel": false
 			},
 			{
 				"name": "alpha",
 				"prerelease": true
-			},
-			{
-				"name": "release"
 			}
 		],
 		"plugins": [
 			"@semantic-release/commit-analyzer",
 			"@semantic-release/release-notes-generator",
 			"@semantic-release/npm",
-			"@semantic-release/github",
-			[
-				"@semantic-release/exec",
-				{
-					"publishCmd": "./scripts/publishLatestRelease.sh ${nextRelease.version}"
-				}
-			]
+			"@semantic-release/github"
 		]
 	},
 	"repository": {


### PR DESCRIPTION
This should "only" publish beta versions to `latest` tag and stop publishing to "beta" tag.