### PR TITLE
Add Realtime api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,13 @@
 				"dotenv": "^16.0.3",
 				"google-protobuf": "^3.21.0",
 				"json-bigint": "^1.0.0",
-				"typescript": "^4.7.2"
+				"typescript": "^4.7.2",
+				"ws": "^8.11.0"
 			},
 			"devDependencies": {
 				"@semantic-release/npm": "^9.0.1",
 				"@types/jest": "^28.1.8",
+				"@types/ws": "^8.5.3",
 				"@typescript-eslint/eslint-plugin": "^5.35.1",
 				"@typescript-eslint/parser": "^5.35.1",
 				"copyfiles": "^2.4.1",
@@ -29,7 +31,7 @@
 				"eslint-plugin-unicorn": "^43.0.2",
 				"eslint-plugin-unused-imports": "^2.0.0",
 				"grpc_tools_node_protoc_ts": "^5.3.2",
-				"grpc-tools": "^1.11.3",
+				"grpc-tools": "^1.12.3",
 				"jest": "^28.1.3",
 				"prettier": "2.7.1",
 				"ts-jest": "^28.0.8",
@@ -1972,6 +1974,15 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
 			"dev": true
+		},
+		"node_modules/@types/ws": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+			"integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.11",
@@ -4285,9 +4296,9 @@
 			"dev": true
 		},
 		"node_modules/grpc-tools": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.3.tgz",
-			"integrity": "sha512-cRSK2uhDKHtZ9hLRM35HxaMAMxyh/L7C96Ojt58DhQBdwTOQlV1VIJHSK6X/pDeSQKhaQqWMFfebt8tIcvRfjQ==",
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.12.3.tgz",
+			"integrity": "sha512-KJgk65dbGqkMuj0xiuT5uk45GcqrFfWTSqpk6Ktd0Ds2cEe9QtPQG/uWCGk185ShXCdgYFLRwfh+FyjQ3nlBNw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -11358,6 +11369,26 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
 		},
+		"node_modules/ws": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -12974,6 +13005,15 @@
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
 			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
 			"dev": true
+		},
+		"@types/ws": {
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+			"integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/yargs": {
 			"version": "17.0.11",
@@ -14682,9 +14722,9 @@
 			}
 		},
 		"grpc-tools": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.11.3.tgz",
-			"integrity": "sha512-cRSK2uhDKHtZ9hLRM35HxaMAMxyh/L7C96Ojt58DhQBdwTOQlV1VIJHSK6X/pDeSQKhaQqWMFfebt8tIcvRfjQ==",
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.12.3.tgz",
+			"integrity": "sha512-KJgk65dbGqkMuj0xiuT5uk45GcqrFfWTSqpk6Ktd0Ds2cEe9QtPQG/uWCGk185ShXCdgYFLRwfh+FyjQ3nlBNw==",
 			"dev": true,
 			"requires": {
 				"@mapbox/node-pre-gyp": "^1.0.5"
@@ -19893,6 +19933,12 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true
+		},
+		"ws": {
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+			"integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+			"requires": {}
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 	"devDependencies": {
 		"@semantic-release/npm": "^9.0.1",
 		"@types/jest": "^28.1.8",
+		"@types/ws": "^8.5.3",
 		"@typescript-eslint/eslint-plugin": "^5.35.1",
 		"@typescript-eslint/parser": "^5.35.1",
 		"copyfiles": "^2.4.1",
@@ -96,7 +97,7 @@
 		"eslint-plugin-unicorn": "^43.0.2",
 		"eslint-plugin-unused-imports": "^2.0.0",
 		"grpc_tools_node_protoc_ts": "^5.3.2",
-		"grpc-tools": "^1.11.3",
+		"grpc-tools": "^1.12.3",
 		"jest": "^28.1.3",
 		"prettier": "2.7.1",
 		"ts-jest": "^28.0.8",
@@ -111,6 +112,7 @@
 		"dotenv": "^16.0.3",
 		"google-protobuf": "^3.21.0",
 		"json-bigint": "^1.0.0",
-		"typescript": "^4.7.2"
+		"typescript": "^4.7.2",
+		"ws": "^8.11.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
 	},
 	"scripts": {
 		"clean": "rm -rf ./src/proto/* && rm -rf dist && rm -rf node_modules",
-		"update_api": "git submodule update --init --recursive && git submodule update --remote --recursive --rebase && git submodule foreach --recursive git reset --hard origin/main",
-		"init_api": "git submodule update --init --recursive",
+		"update_api": "git submodule update --init --recursive && git submodule update --remote --recursive --rebase && git submodule foreach --recursive git reset --hard origin/realtime",
+		"init_api": "git submodule update --init --recursive && git submodule update --remote --recursive --rebase",
 		"protoc": "./scripts/protoc.sh",
 		"lint": "node ./node_modules/eslint/bin/eslint src/ --ext .ts",
 		"lint-fix": "npx eslint --ext .ts --fix src/",

--- a/src/realtime/__test__/test-server.ts
+++ b/src/realtime/__test__/test-server.ts
@@ -48,8 +48,9 @@ export class WsTestServer {
 			ws.send(msg.serializeBinary());
 
 			ws.on("message", (data: Uint8Array) => {
-				console.log("received: %s", data);
 				let msg = proto.RealTimeMessage.deserializeBinary(data).toObject();
+				console.log("received: ", msg);
+
 				this._history.push(msg);
 
 				if (msg.eventType === proto.EventType.MESSAGE) {

--- a/src/realtime/__test__/test-server.ts
+++ b/src/realtime/__test__/test-server.ts
@@ -1,4 +1,18 @@
 import { WebSocketServer } from "ws";
+import * as proto from "../../proto/server/v1/realtime_pb";
+
+let socketId = 0;
+let sessionId = 0;
+
+function getSocketId() {
+	socketId += 1;
+	return socketId.toString();
+}
+
+function getSessionId() {
+	sessionId += 1;
+	return sessionId.toString();
+}
 
 export class WsTestServer {
 	private wss: WebSocketServer;
@@ -9,12 +23,29 @@ export class WsTestServer {
 
 	start() {
 		this.wss.on("connection", (ws) => {
-			ws.on("message", function message(data) {
+			let connected = new proto.ConnectedMessage()
+				.setEvent("connected")
+				.setSocketId(getSocketId())
+				.setSessionId(getSessionId());
+
+			let msg = new proto.RealTimeMessage()
+				.setEventType("connected")
+				.setEvent(connected.serializeBinary());
+
+			console.log("boom", connected.toObject());
+			ws.send(msg.serializeBinary());
+
+			ws.on("message", function (data: Uint8Array) {
 				console.log("received: %s", data);
+				let a = proto.RealTimeMessage.deserializeBinary(data).toObject();
+				let b = proto.MessageEvent.deserializeBinary(a.event as Uint8Array).toObject();
+				console.log(b.data);
+				//@ts-ignore
+				let z = Buffer.from(b.data, "base64").toString("utf-8");
+				console.log("z", z);
+
 				ws.send(data);
 			});
-
-			// ws.send({ channel: "greeting", message: "hello" });
 		});
 	}
 

--- a/src/realtime/__test__/test-server.ts
+++ b/src/realtime/__test__/test-server.ts
@@ -1,0 +1,34 @@
+import { WebSocketServer } from "ws";
+
+export class WsTestServer {
+	private wss: WebSocketServer;
+
+	constructor(port) {
+		this.wss = new WebSocketServer({ port });
+	}
+
+	start() {
+		this.wss.on("connection", (ws) => {
+			ws.on("message", function message(data) {
+				console.log("received: %s", data);
+				ws.send(data);
+			});
+
+			// ws.send({ channel: "greeting", message: "hello" });
+		});
+	}
+
+	async close(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			this.wss.close((err) => {
+				console.log("close", err);
+				if (err) {
+					console.log("ERR", err);
+					reject(err);
+				} else {
+					resolve();
+				}
+			});
+		});
+	}
+}

--- a/src/realtime/__test__/test-server.ts
+++ b/src/realtime/__test__/test-server.ts
@@ -1,8 +1,9 @@
-import { WebSocketServer } from "ws";
+import { WebSocketServer, WebSocket } from "ws";
 import * as proto from "../../proto/server/v1/realtime_pb";
 
 let socketId = 0;
 let sessionId = 0;
+let seq = 0;
 
 function getSocketId() {
 	socketId += 1;
@@ -14,25 +15,34 @@ function getSessionId() {
 	return sessionId.toString();
 }
 
+function getSeq() {
+	seq += 1;
+	return seq.toString();
+}
+
 export class WsTestServer {
 	private wss: WebSocketServer;
+	private clients: Map<string, WebSocket>;
 
 	private _history: proto.RealTimeMessage.AsObject[];
 
 	constructor(port) {
 		this.wss = new WebSocketServer({ port });
+		this.clients = new Map();
 		this._history = [];
 	}
 
 	start() {
 		this.wss.on("connection", (ws) => {
+			let socketId = getSocketId();
+			this.clients.set(socketId, ws);
 			let connected = new proto.ConnectedMessage()
 				.setEvent("connected")
-				.setSocketId(getSocketId())
+				.setSocketId(socketId)
 				.setSessionId(getSessionId());
 
 			let msg = new proto.RealTimeMessage()
-				.setEventType("connected")
+				.setEventType(proto.EventType.CONNECTED)
 				.setEvent(connected.serializeBinary());
 
 			ws.send(msg.serializeBinary());
@@ -42,11 +52,21 @@ export class WsTestServer {
 				let msg = proto.RealTimeMessage.deserializeBinary(data).toObject();
 				this._history.push(msg);
 
-				if (msg.eventType === "message") {
-					ws.send(data);
+				if (msg.eventType === proto.EventType.MESSAGE) {
+					this.clients.forEach((client) => client.send(data));
 				}
 			});
 		});
+	}
+
+	closeConnection(sessionId: string) {
+		let ws = this.clients.get(sessionId);
+
+		if (!ws) {
+			return;
+		}
+
+		ws.close();
 	}
 
 	history() {

--- a/src/realtime/__test__/tigris.realtime.spec.ts
+++ b/src/realtime/__test__/tigris.realtime.spec.ts
@@ -1,5 +1,4 @@
-import { Server } from "@grpc/grpc-js";
-import { RealTime } from "..";
+import { RealTime, Channel } from "..";
 import { WsTestServer } from "./test-server";
 
 const sleep = (time: number) => {
@@ -8,7 +7,7 @@ const sleep = (time: number) => {
 	});
 };
 
-describe("realtime tests", () => {
+describe("realtime message send and receive", () => {
 	let server: WsTestServer;
 
 	beforeEach(async () => {
@@ -20,22 +19,100 @@ describe("realtime tests", () => {
 		await server.close();
 	});
 
-	it("can work", async () => {
-		return new Promise(async (done) => {
-			const realtime = new RealTime();
-			await sleep(100);
+	it("can send and receive", async () => {
+		const realtime = new RealTime();
+		await realtime.connect();
+		try {
+			return new Promise<void>(async (done) => {
+				const channel1 = realtime.getChannel("test-one");
 
-			const channel1 = realtime.getChannel("test-one");
+				channel1.subscribe("greeting", (message) => {
+					expect(message).toEqual("hello world");
+					done();
+				});
 
-			channel1.subscribe("greeting", (message) => {
-				console.log("chan", message);
-				expect(message).toEqual("hello-boom");
-				done(true);
+				await channel1.publish("greeting", "hello world");
 			});
-
-			channel1.publish("greeting", "hello-boom");
-
+		} finally {
 			realtime.close();
-		});
+		}
+	});
+
+	it("can listen to specific messages only", async () => {
+		const realtime = new RealTime();
+		await realtime.connect();
+		try {
+			await new Promise<void>(async (done, reject) => {
+				const channel1 = realtime.getChannel("test-one");
+
+				channel1.subscribe("ch1", (message) => {
+					expect(message).toEqual("hello world");
+					done();
+				});
+
+				channel1.subscribe("ch2", (_message) => {
+					reject("ch2 should not see message");
+				});
+
+				await channel1.publish("ch1", "hello world");
+			});
+		} finally {
+			realtime.close();
+		}
+	});
+
+	it("can subscribe and unsubscribe individual listener", async () => {
+		let messageCount = 0;
+		const realtime = new RealTime();
+		await realtime.connect();
+		const channel1 = realtime.getChannel("test-one");
+
+		let cb = (_) => (messageCount += 1);
+
+		channel1.subscribe("ch1", cb);
+		await checkForDelivery(channel1, "ch1", "msg1");
+
+		channel1.unsubscribe("ch1", cb);
+		await checkForDelivery(channel1, "ch1", "msg2");
+
+		try {
+			expect(messageCount).toEqual(1);
+		} finally {
+			realtime.close();
+		}
+	});
+
+	it("can unsubscribe all listeners", async () => {
+		let messageCount = 0;
+		const realtime = new RealTime();
+		await realtime.connect();
+		const channel1 = realtime.getChannel("test-one");
+
+		channel1.subscribe("ch1", (_) => (messageCount += 1));
+		channel1.subscribe("ch1", (_) => (messageCount += 1));
+		channel1.subscribe("ch1", (_) => (messageCount += 1));
+		channel1.subscribe("ch1", (_) => (messageCount += 1));
+
+		await checkForDelivery(channel1, "ch1", "msg1");
+
+		channel1.unsubscribeAll("ch1");
+
+		await checkForDelivery(channel1, "ch1", "msg2");
+
+		try {
+			expect(messageCount).toEqual(4);
+		} finally {
+			realtime.close();
+		}
 	});
 });
+
+async function checkForDelivery(channel: Channel, msgType: string, message: string) {
+	await new Promise<void>(async (resolve) => {
+		channel.subscribe(msgType, () => {
+			resolve();
+			channel.unsubscribe(msgType, resolve);
+		});
+		await channel.publish(msgType, message);
+	});
+}

--- a/src/realtime/__test__/tigris.realtime.spec.ts
+++ b/src/realtime/__test__/tigris.realtime.spec.ts
@@ -3,10 +3,12 @@ import { WsTestServer } from "./test-server";
 import * as proto from "../../proto/server/v1/realtime_pb";
 
 // TODO:
-// 2. Subscribe recovery - last heard number
-// * unsubscribe on server side
+// 1. Subscribe recovery - last heard number
+// 2 unsubscribe on server side
 // 3. presence
 // 4. logging
+// 5. browser support
+// 6. msg data encoding issue
 
 describe("realtime message send and receive", () => {
 	let server: WsTestServer;
@@ -140,17 +142,16 @@ describe("realtime message send and receive", () => {
 			otherCh1.attach();
 
 			await waitForDelivery(otherCh1, "main", "msg1");
-
-			// server.closeConnection(realtime.socketId());
-
+			server.closeConnection(realtime.socketId());
 			await waitForDelivery(otherCh1, "main", "msg2");
 
-			await sleep(100);
+			await sleep(1001);
 
 			expect(messages.length).toEqual(2);
 			expect(messages[1]).toEqual("msg2");
 		} finally {
 			realtime.close();
+			rt2.close();
 		}
 	});
 });

--- a/src/realtime/__test__/tigris.realtime.spec.ts
+++ b/src/realtime/__test__/tigris.realtime.spec.ts
@@ -1,0 +1,41 @@
+import { Server } from "@grpc/grpc-js";
+import { RealTime } from "..";
+import { WsTestServer } from "./test-server";
+
+const sleep = (time: number) => {
+	return new Promise((resolve) => {
+		setTimeout(resolve, time);
+	});
+};
+
+describe("realtime tests", () => {
+	let server: WsTestServer;
+
+	beforeEach(async () => {
+		server = new WsTestServer(9000);
+		server.start();
+	});
+
+	afterEach(async () => {
+		await server.close();
+	});
+
+	it("can work", async () => {
+		return new Promise(async (done) => {
+			const realtime = new RealTime();
+			await sleep(100);
+
+			const channel1 = realtime.getChannel("test-one");
+
+			channel1.subscribe("greeting", (message) => {
+				console.log("chan", message);
+				expect(message).toEqual("hello-boom");
+				done(true);
+			});
+
+			channel1.publish("greeting", "hello-boom");
+
+			realtime.close();
+		});
+	});
+});

--- a/src/realtime/index.ts
+++ b/src/realtime/index.ts
@@ -37,6 +37,10 @@ export class RealTime {
 		this.channelManager.close();
 		this.transport.close();
 	}
+
+	socketId() {
+		return this.transport.socketId();
+	}
 }
 
 class Presence extends EventEmitter {

--- a/src/realtime/index.ts
+++ b/src/realtime/index.ts
@@ -118,10 +118,3 @@ class ChannelManager {
 		this.channels.clear();
 	}
 }
-
-/*
-    Notes:
-
-    * Browser vs nodejs websocket
-	* Fix message body encoding
-*/

--- a/src/realtime/index.ts
+++ b/src/realtime/index.ts
@@ -1,0 +1,147 @@
+import { TigrisClientConfig } from "../tigris";
+// this needs to go in its own file
+import { WebSocket } from "ws";
+import { EventEmitter } from "node:events";
+import { FlowNode } from "typescript";
+
+type SubscribeCallback = (message: string) => void;
+
+export class RealTime {
+	// private _config: TigrisClientConfig;
+	private channelManager: ChannelManager;
+	private transport: Transport;
+	constructor() {
+		this.transport = new Transport();
+		this.channelManager = new ChannelManager(this.transport);
+		// this._config = config;
+	}
+
+	async connect() {}
+
+	getChannel(name: string): Channel {
+		return this.channelManager.getOrCreate(name);
+	}
+
+	// closes websocket connection
+	close() {
+		this.channelManager.close();
+		this.transport.close();
+	}
+}
+
+class Transport {
+	private listeners: Map<string, SubscribeCallback[]>;
+	private ws: WebSocket;
+
+	constructor() {
+		this.listeners = new Map();
+		this.ws = new WebSocket("ws://127.0.0.1:9000");
+
+		this.ws.on("message", (data) => {
+			let d = String(data);
+			let { channel, msgType, message } = JSON.parse(d);
+			console.log("t - recieved", channel, msgType, message);
+
+			let listeners = this.listeners.get(channel);
+
+			if (!listeners) {
+				return;
+			}
+
+			listeners.forEach((listener) => listener(message));
+		});
+	}
+
+	listen(channelName: string, listener: SubscribeCallback) {
+		if (!this.listeners.has(channelName)) {
+			this.listeners.set(channelName, []);
+		}
+
+		let channelListeners = this.listeners.get(channelName);
+		channelListeners.push(listener);
+	}
+
+	publish(channel: string, msgType: string, message: string) {
+		this.ws.send(JSON.stringify({ channel, msgType, message }));
+	}
+
+	close() {
+		this.ws.close();
+	}
+}
+
+// for browser support we can use https://github.com/primus/eventemitter3
+class Channel extends EventEmitter {
+	private name: string;
+	private hasAttached: boolean;
+	private transport: Transport;
+
+	constructor(name: string, transport: Transport) {
+		super();
+		this.hasAttached = false;
+		this.name = name;
+		this.transport = transport;
+	}
+
+	subscribe(msgType: string, cb: SubscribeCallback) {
+		if (!this.hasAttached) {
+			this.attach();
+		}
+
+		// TODO: make sure we do not see double if we detach and then attach
+
+		this.on(msgType, cb);
+	}
+
+	attach() {
+		this.transport.listen(this.name, (msg) => this.notify(msg));
+		this.hasAttached = true;
+		// this.transport.attach("");
+	}
+
+	detach() {
+		this.hasAttached = false;
+	}
+
+	publish(msgType: string, data: string) {
+		this.transport.publish(this.name, msgType, data);
+	}
+
+	notify(msg: string) {
+		console.log("notify", msg);
+		this.emit("greeting", msg);
+	}
+}
+
+class ChannelManager {
+	channels: Map<string, Channel>;
+	transport: Transport;
+
+	constructor(transport: Transport) {
+		this.channels = new Map<string, Channel>();
+		this.transport = transport;
+	}
+
+	getOrCreate(name): Channel {
+		if (!this.channels.has(name)) {
+			this.channels.set(name, new Channel(name, this.transport));
+		}
+
+		return this.channels.get(name);
+	}
+
+	close() {
+		this.channels.forEach((channel) => channel.detach());
+	}
+}
+
+/*
+    Notes:
+
+    * Might need an async func to connect to server
+        * `async realtime() -> Promise<RealTime>
+    * Browser vs nodejs websocket
+    * 
+
+
+*/

--- a/src/realtime/index.ts
+++ b/src/realtime/index.ts
@@ -1,23 +1,28 @@
 import { TigrisClientConfig } from "../tigris";
 // this needs to go in its own file
-import { WebSocket } from "ws";
 import { EventEmitter } from "node:events";
-import * as proto from "../proto/server/v1/realtime_pb";
-import { connectedMessage, messageEvent, publishMessage, realTimeMessage } from "./messages";
+import { Transport } from "./transport";
+import { MessageEvent } from "./messages";
 
 type SubscribeCallback = (string) => void;
-type MessageEvent = proto.MessageEvent.AsObject;
-type MessageEventListener = (MessageEvent: MessageEvent) => void;
+
+export interface RealTimeConfig {
+	/*
+	 * An id used to identify this client when using the presence feature.
+	 * If the client id is not set, an error will be thrown when using any presence features
+	 */
+	clientId?: string;
+}
 
 export class RealTime {
-	// private _config: TigrisClientConfig;
+	private _config: RealTimeConfig;
 	private channelManager: ChannelManager;
 	private transport: Transport;
-	constructor() {
+	constructor(config: RealTimeConfig = {}) {
 		this.transport = new Transport();
 		this.channelManager = new ChannelManager(this.transport);
 
-		// this._config = config;
+		this._config = config;
 	}
 
 	async connect() {
@@ -34,85 +39,9 @@ export class RealTime {
 	}
 }
 
-interface Session {
-	sessionId: string;
-	socketId: string;
-}
-
-type ConnectionState = "failed" | "connecting" | "connected" | "uninitialized";
-
-class Transport {
-	private listeners: Map<string, MessageEventListener[]>;
-	private ws: WebSocket;
-	private session: Session;
-	private _isConnected: Promise<void>;
-	private _connectionState: ConnectionState = "uninitialized";
-
+class Presence extends EventEmitter {
 	constructor() {
-		this.listeners = new Map();
-		this.ws = new WebSocket("ws://127.0.0.1:9000");
-		this.ws.binaryType = "arraybuffer";
-
-		let connectionResolved = () => {};
-
-		this._isConnected = new Promise((resolve) => {
-			connectionResolved = resolve;
-		});
-
-		this.ws.on("message", (data: Uint8Array) => {
-			const msg = realTimeMessage(data);
-
-			switch (msg.eventType) {
-				case "connected":
-					this.session = connectedMessage(msg.event);
-
-					connectionResolved();
-					this._connectionState = "connected";
-
-					console.log("connected with", this.session);
-					return;
-
-				case "message":
-					let channelMsg = messageEvent(msg.event);
-					this.handleChannelMessage(channelMsg);
-					return;
-				default:
-					throw new Error(`unknown message type ${msg.eventType}`);
-			}
-		});
-	}
-
-	connectionState(): ConnectionState {
-		return this._connectionState;
-	}
-
-	handleChannelMessage(msg: MessageEvent) {
-		const listeners = this.listeners.get(msg.channel);
-		msg.data = Buffer.from(msg.data as string, "base64").toString("utf8");
-
-		listeners.forEach((listener) => listener(msg));
-	}
-
-	isConnected(): Promise<void> {
-		return this._isConnected;
-	}
-
-	listen(channelName: string, listener: MessageEventListener) {
-		if (!this.listeners.has(channelName)) {
-			this.listeners.set(channelName, []);
-		}
-
-		const channelListeners = this.listeners.get(channelName);
-		channelListeners.push(listener);
-	}
-
-	async publish(channel: string, name: string, message: string) {
-		const msg = publishMessage(channel, name, message);
-		this.ws.send(msg);
-	}
-
-	close() {
-		this.ws.close();
+		super();
 	}
 }
 

--- a/src/realtime/messages.ts
+++ b/src/realtime/messages.ts
@@ -1,5 +1,7 @@
 import * as proto from "../proto/server/v1/realtime_pb";
 
+export type MessageEvent = proto.MessageEvent.AsObject;
+
 export function connectedMessage(event: Uint8Array | string): proto.ConnectedMessage.AsObject {
 	return proto.ConnectedMessage.deserializeBinary(event as Uint8Array).toObject();
 }
@@ -15,6 +17,10 @@ export function publishMessage(channel: string, name: string, message: string) {
 		.setData(Buffer.from(message).toString("base64"));
 
 	return createRTMessage("message", msg.serializeBinary());
+}
+
+export function heartbeatMessage() {
+	return createRTMessage("heartbeat", new Uint8Array());
 }
 
 export function createRTMessage(eventType: string, event: Uint8Array) {

--- a/src/realtime/messages.ts
+++ b/src/realtime/messages.ts
@@ -16,14 +16,14 @@ export function publishMessage(channel: string, name: string, message: string) {
 		.setName(name)
 		.setData(Buffer.from(message).toString("base64"));
 
-	return createRTMessage("message", msg.serializeBinary());
+	return createRTMessage(proto.EventType.MESSAGE, msg.serializeBinary());
 }
 
 export function heartbeatMessage() {
-	return createRTMessage("heartbeat", new Uint8Array());
+	return createRTMessage(proto.EventType.HEARTBEAT, new Uint8Array());
 }
 
-export function createRTMessage(eventType: string, event: Uint8Array) {
+export function createRTMessage(eventType: proto.EventType, event: Uint8Array) {
 	return new proto.RealTimeMessage().setEventType(eventType).setEvent(event).serializeBinary();
 }
 

--- a/src/realtime/messages.ts
+++ b/src/realtime/messages.ts
@@ -1,0 +1,26 @@
+import * as proto from "../proto/server/v1/realtime_pb";
+
+export function connectedMessage(event: Uint8Array | string): proto.ConnectedMessage.AsObject {
+	return proto.ConnectedMessage.deserializeBinary(event as Uint8Array).toObject();
+}
+
+export function messageEvent(event: Uint8Array | string): proto.MessageEvent.AsObject {
+	return proto.MessageEvent.deserializeBinary(event as Uint8Array).toObject();
+}
+
+export function publishMessage(channel: string, name: string, message: string) {
+	const msg = new proto.MessageEvent()
+		.setChannel(channel)
+		.setName(name)
+		.setData(Buffer.from(message).toString("base64"));
+
+	return createRTMessage("message", msg.serializeBinary());
+}
+
+export function createRTMessage(eventType: string, event: Uint8Array) {
+	return new proto.RealTimeMessage().setEventType(eventType).setEvent(event).serializeBinary();
+}
+
+export function realTimeMessage(data: Uint8Array) {
+	return proto.RealTimeMessage.deserializeBinary(data).toObject();
+}

--- a/src/realtime/transport.ts
+++ b/src/realtime/transport.ts
@@ -7,6 +7,7 @@ import {
 	MessageEvent,
 } from "./messages";
 import { WebSocket } from "ws";
+import { EventEmitter } from "node:events";
 import * as proto from "../proto/server/v1/realtime_pb";
 
 type MessageEventListener = (MessageEvent: MessageEvent) => void;
@@ -19,54 +20,82 @@ interface Session {
 	socketId: string;
 }
 
-type ConnectionState = "failed" | "connecting" | "connected" | "uninitialized";
+type ConnectionState =
+	| "failed"
+	| "connecting"
+	| "connected"
+	| "uninitialized"
+	| "closing"
+	| "closed";
 
-export class Transport {
-	private listeners: Map<string, MessageEventListener[]>;
+export class Transport extends EventEmitter {
+	private channelListeners: Map<string, MessageEventListener[]>;
 	private ws: WebSocket;
 	private session: Session;
 	private _isConnected: Promise<void>;
 	private _connectionState: ConnectionState = "uninitialized";
 	private heartbeatId: number | NodeJS.Timeout;
 	private config: TransportConfig;
+	private connectionResolved: (value: void | PromiseLike<void>) => void;
 
 	constructor(config: TransportConfig = { heartbeatTimeout: 1000 }) {
+		super();
+
 		this.config = config;
-		this.listeners = new Map();
+		this.channelListeners = new Map();
+
+		this.establishConnection();
+	}
+
+	establishConnection() {
 		this.ws = new WebSocket("ws://127.0.0.1:9000");
 		this.ws.binaryType = "arraybuffer";
+		this._connectionState = "connecting";
 
-		let connectionResolved = () => {};
-
-		this._isConnected = new Promise((resolve) => {
-			connectionResolved = resolve;
+		this._isConnected = new Promise<void>((resolve) => {
+			this.connectionResolved = resolve;
 		});
 
-		this.ws.on("open", () => {
-			this.restartHeartbeat();
-		});
+		this.ws.on("open", () => this.restartHeartbeat());
+		this.ws.on("error", (err) => this.onError(err));
+		this.ws.on("close", (_code, _reason) => this.onClose());
+		this.ws.on("message", (data: Uint8Array) => this.onMessage(data));
+	}
 
-		this.ws.on("message", (data: Uint8Array) => {
-			const msg = realTimeMessage(data);
+	onClose() {
+		clearTimeout(this.heartbeatId);
+		if (this._connectionState === "closing") {
+			this._connectionState = "closed";
+			return;
+		}
 
-			switch (msg.eventType) {
-				case proto.EventType.CONNECTED:
-					this.session = connectedMessage(msg.event);
+		this.establishConnection();
+	}
 
-					connectionResolved();
-					this._connectionState = "connected";
+	onError(err: Error) {
+		console.error(err);
+	}
 
-					console.log("connected with", this.session);
-					return;
+	onMessage(data: Uint8Array) {
+		const msg = realTimeMessage(data);
 
-				case proto.EventType.MESSAGE:
-					let channelMsg = messageEvent(msg.event);
-					this.handleChannelMessage(channelMsg);
-					return;
-				default:
-					throw new Error(`unknown message type ${msg.eventType}`);
-			}
-		});
+		switch (msg.eventType) {
+			case proto.EventType.CONNECTED:
+				this.session = connectedMessage(msg.event);
+				this.connectionResolved();
+
+				this._connectionState = "connected";
+
+				console.log("connected with", this.session);
+				return;
+
+			case proto.EventType.MESSAGE:
+				let channelMsg = messageEvent(msg.event);
+				this.handleChannelMessage(channelMsg);
+				return;
+			default:
+				throw new Error(`unknown message type ${msg.eventType}`);
+		}
 	}
 
 	restartHeartbeat() {
@@ -88,7 +117,7 @@ export class Transport {
 	}
 
 	handleChannelMessage(msg: MessageEvent) {
-		const listeners = this.listeners.get(msg.channel);
+		const listeners = this.channelListeners.get(msg.channel);
 		msg.data = Buffer.from(msg.data as string, "base64").toString("utf8");
 
 		listeners.forEach((listener) => listener(msg));
@@ -99,11 +128,11 @@ export class Transport {
 	}
 
 	listen(channelName: string, listener: MessageEventListener) {
-		if (!this.listeners.has(channelName)) {
-			this.listeners.set(channelName, []);
+		if (!this.channelListeners.has(channelName)) {
+			this.channelListeners.set(channelName, []);
 		}
 
-		const channelListeners = this.listeners.get(channelName);
+		const channelListeners = this.channelListeners.get(channelName);
 		channelListeners.push(listener);
 	}
 
@@ -118,6 +147,7 @@ export class Transport {
 	}
 
 	close() {
+		this._connectionState = "closing";
 		clearTimeout(this.heartbeatId);
 		this.ws.close();
 	}

--- a/src/realtime/transport.ts
+++ b/src/realtime/transport.ts
@@ -1,0 +1,118 @@
+import {
+	connectedMessage,
+	messageEvent,
+	publishMessage,
+	realTimeMessage,
+	heartbeatMessage,
+	MessageEvent,
+} from "./messages";
+import { WebSocket } from "ws";
+
+type MessageEventListener = (MessageEvent: MessageEvent) => void;
+interface TransportConfig {
+	heartbeatTimeout: number;
+}
+
+interface Session {
+	sessionId: string;
+	socketId: string;
+}
+
+type ConnectionState = "failed" | "connecting" | "connected" | "uninitialized";
+
+export class Transport {
+	private listeners: Map<string, MessageEventListener[]>;
+	private ws: WebSocket;
+	private session: Session;
+	private _isConnected: Promise<void>;
+	private _connectionState: ConnectionState = "uninitialized";
+	private heartbeatId: number | NodeJS.Timeout;
+	private config: TransportConfig;
+
+	constructor(config: TransportConfig = { heartbeatTimeout: 1000 }) {
+		this.config = config;
+		this.listeners = new Map();
+		this.ws = new WebSocket("ws://127.0.0.1:9000");
+		this.ws.binaryType = "arraybuffer";
+
+		let connectionResolved = () => {};
+
+		this._isConnected = new Promise((resolve) => {
+			connectionResolved = resolve;
+		});
+
+		this.ws.on("open", () => {
+			this.restartHeartbeat();
+		});
+
+		this.ws.on("message", (data: Uint8Array) => {
+			const msg = realTimeMessage(data);
+
+			switch (msg.eventType) {
+				case "connected":
+					this.session = connectedMessage(msg.event);
+
+					connectionResolved();
+					this._connectionState = "connected";
+
+					console.log("connected with", this.session);
+					return;
+
+				case "message":
+					let channelMsg = messageEvent(msg.event);
+					this.handleChannelMessage(channelMsg);
+					return;
+				default:
+					throw new Error(`unknown message type ${msg.eventType}`);
+			}
+		});
+	}
+
+	restartHeartbeat() {
+		clearTimeout(this.heartbeatId);
+		this.heartbeatId = setTimeout(() => this.sendHeartbeat(), this.config.heartbeatTimeout);
+	}
+
+	send(msg: Uint8Array) {
+		this.ws.send(msg);
+	}
+
+	sendHeartbeat() {
+		this.restartHeartbeat();
+		this.ws.send(heartbeatMessage());
+	}
+
+	connectionState(): ConnectionState {
+		return this._connectionState;
+	}
+
+	handleChannelMessage(msg: MessageEvent) {
+		const listeners = this.listeners.get(msg.channel);
+		msg.data = Buffer.from(msg.data as string, "base64").toString("utf8");
+
+		listeners.forEach((listener) => listener(msg));
+	}
+
+	isConnected(): Promise<void> {
+		return this._isConnected;
+	}
+
+	listen(channelName: string, listener: MessageEventListener) {
+		if (!this.listeners.has(channelName)) {
+			this.listeners.set(channelName, []);
+		}
+
+		const channelListeners = this.listeners.get(channelName);
+		channelListeners.push(listener);
+	}
+
+	async publish(channel: string, name: string, message: string) {
+		const msg = publishMessage(channel, name, message);
+		this.send(msg);
+	}
+
+	close() {
+		clearTimeout(this.heartbeatId);
+		this.ws.close();
+	}
+}

--- a/src/realtime/transport.ts
+++ b/src/realtime/transport.ts
@@ -7,6 +7,7 @@ import {
 	MessageEvent,
 } from "./messages";
 import { WebSocket } from "ws";
+import * as proto from "../proto/server/v1/realtime_pb";
 
 type MessageEventListener = (MessageEvent: MessageEvent) => void;
 interface TransportConfig {
@@ -49,7 +50,7 @@ export class Transport {
 			const msg = realTimeMessage(data);
 
 			switch (msg.eventType) {
-				case "connected":
+				case proto.EventType.CONNECTED:
 					this.session = connectedMessage(msg.event);
 
 					connectionResolved();
@@ -58,7 +59,7 @@ export class Transport {
 					console.log("connected with", this.session);
 					return;
 
-				case "message":
+				case proto.EventType.MESSAGE:
 					let channelMsg = messageEvent(msg.event);
 					this.handleChannelMessage(channelMsg);
 					return;
@@ -109,6 +110,11 @@ export class Transport {
 	async publish(channel: string, name: string, message: string) {
 		const msg = publishMessage(channel, name, message);
 		this.send(msg);
+	}
+
+	// Returns the connection session socket id
+	socketId(): string | undefined {
+		return this.session?.sessionId;
 	}
 
 	close() {

--- a/src/tigris.ts
+++ b/src/tigris.ts
@@ -6,6 +6,7 @@ import { ChannelCredentials, Metadata, status } from "@grpc/grpc-js";
 import { CreateProjectRequest as ProtoCreateProjectRequest } from "./proto/server/v1/api_pb";
 import { GetInfoRequest as ProtoGetInfoRequest } from "./proto/server/v1/observability_pb";
 import { HealthCheckInput as ProtoHealthCheckInput } from "./proto/server/v1/health_pb";
+import { RealTime } from "./realtime";
 
 import path from "node:path";
 import appRootPath from "app-root-path";
@@ -241,6 +242,10 @@ export class Tigris {
 
 	public getDatabase(): DB {
 		return new DB(this._config.projectName, this.grpcClient, this._config);
+	}
+
+	public realtime(): RealTime {
+		return new RealTime(this._config);
 	}
 
 	public getServerMetadata(): Promise<ServerMetadata> {

--- a/src/tigris.ts
+++ b/src/tigris.ts
@@ -244,9 +244,9 @@ export class Tigris {
 		return new DB(this._config.projectName, this.grpcClient, this._config);
 	}
 
-	public realtime(): RealTime {
-		return new RealTime(this._config);
-	}
+	// public realtime(): RealTime {
+	// 	return new RealTime(this._config);
+	// }
 
 	public getServerMetadata(): Promise<ServerMetadata> {
 		return new Promise<ServerMetadata>((resolve, reject) => {


### PR DESCRIPTION
This is still in early development. Current outstanding work:

- [ ] Recover connection and Subscribe recovery - last heard number
- [ ] unsubscribe on server side
- [ ] presence
- [ ] logging
- [ ] browser support
- [ ] msg data encoding issue
- [ ] work with Tigris server

The API looks like this:

```ts
const realtime = new RealTime();
await realtime.connect();

const channel1 = realtime.getChannel("channel-name");

channel1.subscribe("greeting", (message) => {
  console.log("Recieved ", message); 
});

await channel1.publish("greeting", "hello world");


```