### PR TITLE
feat: Support for Date types in schema and filter

### DIFF
--- a/src/__tests__/data/decoratedModels/users.ts
+++ b/src/__tests__/data/decoratedModels/users.ts
@@ -30,8 +30,8 @@ export class User implements TigrisCollectionType {
 	@PrimaryKey({order: 1})
 	id: number;
 
-	@Field(TigrisDataTypes.DATE_TIME)
-	created: string;
+	@Field()
+	created: Date;
 
 	@Field({elements: Identity})
 	identities: Array<Identity>;

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -35,25 +35,25 @@ describe("filters tests", () => {
 
 	});
 
-	it ("serializes Date object to string", () => {
+	it("persists date string as it is", () => {
 		const dateFilter: SelectorFilter<IUser1> = {
 			op: SelectorFilterOperator.GT,
 			fields: {
 				createdAt: "1980-01-01T18:29:28.000Z"
 			}
-		}
+		};
 		expect(Utility.filterToString(dateFilter)).toBe("{\"createdAt\":{\"$gt\":\"1980-01-01T18:29:28.000Z\"}}");
-	})
+	});
 
-	it ("persists date string as it is", () => {
+	it("serializes Date object to string", () => {
 		const dateFilter: SelectorFilter<IUser1> = {
 			op: SelectorFilterOperator.LT,
 			fields: {
 				updatedAt: new Date("1980-01-01")
 			}
-		}
+		};
 		expect(Utility.filterToString(dateFilter)).toBe("{\"updatedAt\":{\"$lt\":\"1980-01-01T00:00:00.000Z\"}}");
-	})
+	});
 
 	it("simplerSelectorWithinLogicalFilterTest", () => {
 		const filter1: LogicalFilter<IUser> = {
@@ -114,7 +114,7 @@ describe("filters tests", () => {
 			op: SelectorFilterOperator.EQ,
 			fields: {
 				id: BigInt(1),
-				name: "alice",
+				name: "alice"
 			}
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe("{\"id\":1,\"name\":\"alice\"}");
@@ -244,12 +244,12 @@ describe("filters tests", () => {
 				{
 					op: SelectorFilterOperator.EQ,
 					fields: {
-						name: "alice",
+						name: "alice"
 					}
 				},
 				{
 					address: {
-						city: "Paris",
+						city: "Paris"
 					}
 				}
 			]
@@ -262,7 +262,7 @@ describe("filters tests", () => {
 					fields: {
 						address: {
 							zipcode: 1200
-						},
+						}
 					}
 				},
 				{
@@ -287,7 +287,7 @@ describe("filters tests", () => {
 				{
 					op: SelectorFilterOperator.EQ,
 					fields: {
-						name: "alice",
+						name: "alice"
 					}
 				},
 				{
@@ -304,7 +304,7 @@ describe("filters tests", () => {
 				{
 					op: SelectorFilterOperator.EQ,
 					fields: {
-						name: "emma",
+						name: "emma"
 					}
 				},
 				{
@@ -331,7 +331,7 @@ export interface IUser extends TigrisCollectionType {
 
 @TigrisCollection("user1")
 export class IUser1 implements TigrisCollectionType {
-	@PrimaryKey({order: 1})
+	@PrimaryKey({ order: 1 })
 	id: bigint;
 	@Field()
 	name: string;
@@ -342,7 +342,7 @@ export class IUser1 implements TigrisCollectionType {
 	@Field(TigrisDataTypes.DATE_TIME)
 	createdAt: string;
 	@Field()
-	updatedAt: Date
+	updatedAt: Date;
 }
 
 export interface IUser2 extends TigrisCollectionType {

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -5,8 +5,12 @@ import {
 	SelectorFilter,
 	SelectorFilterOperator,
 	TigrisCollectionType,
+	TigrisDataTypes
 } from "../types";
-import {Utility} from "../utility";
+import { Utility } from "../utility";
+import { TigrisCollection } from "../decorators/tigris-collection";
+import { PrimaryKey } from "../decorators/tigris-primary-key";
+import { Field } from "../decorators/tigris-field";
 
 describe("filters tests", () => {
 	it("simpleSelectorFilterTest", () => {
@@ -30,6 +34,26 @@ describe("filters tests", () => {
 		expect(Utility.filterToString(filter3)).toBe("{\"isActive\":true}");
 
 	});
+
+	it ("serializes Date object to string", () => {
+		const dateFilter: SelectorFilter<IUser1> = {
+			op: SelectorFilterOperator.GT,
+			fields: {
+				createdAt: "1980-01-01T18:29:28.000Z"
+			}
+		}
+		expect(Utility.filterToString(dateFilter)).toBe("{\"createdAt\":{\"$gt\":\"1980-01-01T18:29:28.000Z\"}}");
+	})
+
+	it ("persists date string as it is", () => {
+		const dateFilter: SelectorFilter<IUser1> = {
+			op: SelectorFilterOperator.LT,
+			fields: {
+				updatedAt: new Date("1980-01-01")
+			}
+		}
+		expect(Utility.filterToString(dateFilter)).toBe("{\"updatedAt\":{\"$lt\":\"1980-01-01T00:00:00.000Z\"}}");
+	})
 
 	it("simplerSelectorWithinLogicalFilterTest", () => {
 		const filter1: LogicalFilter<IUser> = {
@@ -305,11 +329,20 @@ export interface IUser extends TigrisCollectionType {
 	balance: number;
 }
 
-export interface IUser1 extends TigrisCollectionType {
-	id: BigInt;
+@TigrisCollection("user1")
+export class IUser1 implements TigrisCollectionType {
+	@PrimaryKey({order: 1})
+	id: bigint;
+	@Field()
 	name: string;
+	@Field()
 	balance: number;
+	@Field()
 	isActive: boolean;
+	@Field(TigrisDataTypes.DATE_TIME)
+	createdAt: string;
+	@Field()
+	updatedAt: Date
 }
 
 export interface IUser2 extends TigrisCollectionType {

--- a/src/decorators/tigris-field.ts
+++ b/src/decorators/tigris-field.ts
@@ -106,7 +106,7 @@ export function Field(
 					Reflect && Reflect.getMetadata
 						? Reflect.getMetadata("design:type", target, propertyName)
 						: undefined;
-				propertyType = ReflectedTypeToTigrisType.get(reflectedType.name);
+				propertyType = getTigrisTypeFromReflectedType(reflectedType.name);
 			} catch {
 				throw new ReflectionNotEnabled(target, propertyName);
 			}
@@ -144,15 +144,27 @@ export function Field(
 	};
 }
 
-const ReflectedTypeToTigrisType: Map<string, TigrisDataTypes> = new Map([
-	["String", TigrisDataTypes.STRING],
-	["Boolean", TigrisDataTypes.BOOLEAN],
-	["Object", TigrisDataTypes.OBJECT],
-	["Array", TigrisDataTypes.ARRAY],
-	["Set", TigrisDataTypes.ARRAY],
-	["Number", TigrisDataTypes.NUMBER],
-	["BigInt", TigrisDataTypes.NUMBER_BIGINT],
-]);
+function getTigrisTypeFromReflectedType(reflectedType: string): TigrisDataTypes | undefined {
+	switch (reflectedType) {
+		case "String":
+			return TigrisDataTypes.STRING;
+		case "Boolean":
+			return TigrisDataTypes.BOOLEAN;
+		case "Object":
+			return TigrisDataTypes.OBJECT;
+		case "Array":
+		case "Set":
+			return TigrisDataTypes.ARRAY;
+		case "Number":
+			return TigrisDataTypes.NUMBER;
+		case "BigInt":
+			return TigrisDataTypes.NUMBER_BIGINT;
+		case "Date":
+			return TigrisDataTypes.DATE_TIME;
+		default:
+			return undefined;
+	}
+}
 
 function isEmbeddedOption(
 	options: TigrisFieldOptions | EmbeddedFieldOptions

--- a/src/error.ts
+++ b/src/error.ts
@@ -33,7 +33,8 @@ export class ReflectionNotEnabled extends TigrisError {
 		super(
 			`Cannot infer property "type" for ${object.constructor.name}#${propertyName} using Reflection.
 			Ensure that "experimentalDecorators" and "emitDecoratorMetadata" options are set to true in
-			"tsconfig.json" and "reflect-metadata" npm package is added to dependencies in "package.json"`
+			"tsconfig.json" and "reflect-metadata" npm package is added to dependencies in "package.json".
+			Alternatively, specify the property's "field type" manually.`
 		);
 	}
 

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -223,12 +223,16 @@ export const Utility = {
 			if (!ob.hasOwnProperty(key)) continue;
 
 			if (typeof ob[key] == "object" && ob[key] !== null) {
-				const flatObject = Utility._flattenObj(ob[key]);
-				for (const x in flatObject) {
-					// eslint-disable-next-line no-prototype-builtins
-					if (!flatObject.hasOwnProperty(x)) continue;
-
-					toReturn[key + "." + x] = flatObject[x];
+				const value = ob[key];
+				if (value.constructor.name === "Date") {
+					toReturn[key] = (value as Date).toJSON();
+				} else {
+					const flatObject = Utility._flattenObj(value);
+					for (const x in flatObject) {
+						// eslint-disable-next-line no-prototype-builtins
+						if (!flatObject.hasOwnProperty(x)) continue;
+						toReturn[key + "." + x] = flatObject[x];
+					}
 				}
 			} else {
 				toReturn[key] = ob[key];


### PR DESCRIPTION
- Now decorated schema can automatically interpret `Date` fields as `DATE_TIME` in schema. E.g.-, [this unit test](https://github.com/tigrisdata/tigris-client-ts/pull/194/files#diff-8349b4caf0b5bb16362a7cf27f05522b35bdcfb5521114f9b4befd5dc17c1255R33-R34)

- Users can still explicitly specify a schema type of DATE_TIME to be used internally as string. See [this](https://github.com/tigrisdata/tigris-client-ts/pull/194/files#diff-1b1c836ae8f3e670b3567eb76d3a52ebb591b8e45076cd92be50c183a73508fcR342)

- `Date` objects can be used  as it is in Filters.