### PR TITLE
feat: Added Caches API

### DIFF
--- a/src/__tests__/test-cache-service.ts
+++ b/src/__tests__/test-cache-service.ts
@@ -1,0 +1,141 @@
+import { CacheService, ICacheServer } from "../proto/server/v1/cache_grpc_pb";
+import { sendUnaryData, ServerUnaryCall } from "@grpc/grpc-js";
+import {
+	CacheMetadata,
+	CreateCacheRequest,
+	CreateCacheResponse,
+	DeleteCacheRequest,
+	DeleteCacheResponse,
+	DelResponse,
+	GetRequest,
+	GetResponse,
+	KeysRequest,
+	KeysResponse,
+	ListCachesRequest,
+	ListCachesResponse,
+	SetRequest,
+	SetResponse,
+} from "../proto/server/v1/cache_pb";
+import { DelRequest } from "../../dist/proto/server/v1/cache_pb";
+import { Utility } from "../utility";
+
+export class TestCacheService {
+	private static CACHE_MAP = new Map<string, Map<string, string>>();
+
+	static reset() {
+		TestCacheService.CACHE_MAP.clear();
+	}
+	public impl: ICacheServer = {
+		createCache(
+			call: ServerUnaryCall<CreateCacheRequest, CreateCacheResponse>,
+			callback: sendUnaryData<CreateCacheResponse>
+		): void {
+			const cacheName = call.request.getProject() + "_" + call.request.getName();
+			if (TestCacheService.CACHE_MAP.has(cacheName)) {
+				callback(new Error(), undefined);
+			} else {
+				TestCacheService.CACHE_MAP.set(cacheName, new Map<string, string>());
+				callback(
+					undefined,
+					new CreateCacheResponse().setStatus("created").setMessage("Cache created successfully")
+				);
+			}
+		},
+		del(
+			call: ServerUnaryCall<DelRequest, DelResponse>,
+			callback: sendUnaryData<DelResponse>
+		): void {
+			const cacheName = call.request.getProject() + "_" + call.request.getName();
+			if (TestCacheService.CACHE_MAP.has(cacheName)) {
+				if (TestCacheService.CACHE_MAP.get(cacheName).has(call.request.getKey())) {
+					TestCacheService.CACHE_MAP.get(cacheName).delete(call.request.getKey());
+					callback(
+						undefined,
+						new DelResponse().setStatus("deleted").setMessage("Deleted key count# 1")
+					);
+				}
+			} else {
+				callback(new Error("cache does not exist"), undefined);
+			}
+		},
+		deleteCache(
+			call: ServerUnaryCall<DeleteCacheRequest, DeleteCacheResponse>,
+			callback: sendUnaryData<DeleteCacheResponse>
+		): void {
+			const cacheName = call.request.getProject() + "_" + call.request.getName();
+			if (TestCacheService.CACHE_MAP.has(cacheName)) {
+				TestCacheService.CACHE_MAP.delete(cacheName);
+				callback(
+					undefined,
+					new DeleteCacheResponse().setStatus("deleted").setMessage("Deleted cache")
+				);
+			} else {
+				callback(new Error("cache does not exist"), undefined);
+			}
+		},
+		get(
+			call: ServerUnaryCall<GetRequest, GetResponse>,
+			callback: sendUnaryData<GetResponse>
+		): void {
+			const cacheName = call.request.getProject() + "_" + call.request.getName();
+			if (TestCacheService.CACHE_MAP.has(cacheName)) {
+				if (TestCacheService.CACHE_MAP.get(cacheName).has(call.request.getKey())) {
+					const value = TestCacheService.CACHE_MAP.get(cacheName).get(call.request.getKey());
+					callback(undefined, new GetResponse().setValue(value));
+				} else {
+					callback(new Error("cache key does not exist"), undefined);
+				}
+			} else {
+				callback(new Error("cache does not exist"), undefined);
+			}
+		},
+		keys(
+			call: ServerUnaryCall<KeysRequest, KeysResponse>,
+			callback: sendUnaryData<KeysResponse>
+		): void {
+			const cacheName = call.request.getProject() + "_" + call.request.getName();
+			if (TestCacheService.CACHE_MAP.has(cacheName)) {
+				const result: Array<string> = new Array<string>();
+				for (let key of TestCacheService.CACHE_MAP.get(cacheName).keys()) {
+					result.push(key);
+				}
+				callback(undefined, new KeysResponse().setKeysList(result));
+			} else {
+				callback(new Error("cache does not exist"), undefined);
+			}
+		},
+		listCaches(
+			call: ServerUnaryCall<ListCachesRequest, ListCachesResponse>,
+			callback: sendUnaryData<ListCachesResponse>
+		): void {
+			const result: Array<CacheMetadata> = new Array<CacheMetadata>();
+			for (let key of TestCacheService.CACHE_MAP.keys()) {
+				if (key.startsWith(call.request.getProject()))
+					result.push(
+						new CacheMetadata().setName(key.replace(call.request.getProject() + "_", ""))
+					);
+			}
+			callback(undefined, new ListCachesResponse().setCachesList(result));
+		},
+		set(
+			call: ServerUnaryCall<SetRequest, SetResponse>,
+			callback: sendUnaryData<SetResponse>
+		): void {
+			const cacheName = call.request.getProject() + "_" + call.request.getName();
+			if (TestCacheService.CACHE_MAP.has(cacheName)) {
+				TestCacheService.CACHE_MAP.get(cacheName).set(
+					call.request.getKey(),
+					call.request.getValue_asB64()
+				);
+				callback(undefined, new SetResponse().setStatus("set").setMessage("set" + " successfully"));
+			} else {
+				callback(new Error("cache does not exist"), undefined);
+			}
+		},
+	};
+}
+
+export default {
+	service: CacheService,
+	handler: new TestCacheService(),
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -309,6 +309,93 @@ export class TransactionResponse extends TigrisResponse {
 	}
 }
 
+export class CacheMetadata {
+	private readonly _name: string;
+
+	constructor(name: string) {
+		this._name = name;
+	}
+
+	get name(): string {
+		return this._name;
+	}
+}
+export class ListCachesResponse {
+	private readonly _caches: CacheMetadata[];
+
+	constructor(caches: CacheMetadata[]) {
+		this._caches = caches;
+	}
+
+	get caches(): CacheMetadata[] {
+		return this._caches;
+	}
+}
+
+export class DeleteCacheResponse extends TigrisResponse {
+	private readonly _message: string;
+
+	constructor(status: string, message: string) {
+		super(status);
+		this._message = message;
+	}
+
+	get message(): string {
+		return this._message;
+	}
+}
+
+export class CacheSetResponse extends TigrisResponse {
+	private readonly _message: string;
+
+	constructor(status: string, message: string) {
+		super(status);
+		this._message = message;
+	}
+
+	get message(): string {
+		return this._message;
+	}
+}
+
+export class CacheDelResponse extends TigrisResponse {
+	private readonly _message: string;
+
+	constructor(status: string, message: string) {
+		super(status);
+		this._message = message;
+	}
+
+	get message(): string {
+		return this._message;
+	}
+}
+
+export interface CacheSetOptions {
+	// optional ttl in seconds
+	ex: number;
+	// optional ttl in ms
+	px: number;
+	// only set if key doesn't exist
+	nx: boolean;
+	// only set if key exists
+	xx: boolean;
+	// get the old value as part of response
+	get: boolean;
+}
+
+export class CacheGetResponse {
+	private readonly _value: object;
+
+	constructor(value: object) {
+		this._value = value;
+	}
+
+	get value(): object {
+		return this._value;
+	}
+}
+
 export class ServerMetadata {
 	private readonly _serverVersion: string;
 

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -467,6 +467,10 @@ export const Utility = {
 		return Buffer.from(b64String, "base64").toString("binary");
 	},
 
+	_base64DecodeToObject(b64String: string, config: TigrisClientConfig): object {
+		return this.jsonStringToObj(Buffer.from(b64String, "base64").toString("binary"), config);
+	},
+
 	createFacetQueryOptions(options?: Partial<FacetQueryOptions>): FacetQueryOptions {
 		const defaults = { size: 10, type: FacetQueryFieldType.VALUE };
 		return { ...defaults, ...options };


### PR DESCRIPTION
## Describe your changes
Surfacing Caches API to TypeScript SDK.


```
// create cache
const c1 = await tigris.createCacheIfNotExists("c1");

// set
await c1.set("k1", "val1");
await c1.set("k2", 123");
await c1.set("k3", true);
await c1.set("k4", {"a": "A", "n": 123});

// get
const value = await c1.get("k1").value;

// del
await c1.del("k1");

// keys
const keys: string[] = await c1.keys();

// list caches
const caches = await tigris.listCaches();

// delete cache
await tigris.deleteCache("c1");
```

## How best to test these changes

- Unit test with mock Tigris server (included)
- Tested manually with starter app against Tigris server.

## Issue ticket number and link
