### PR TITLE
feat: Implemented getSet method for cache

### DIFF
--- a/src/__tests__/test-cache-service.ts
+++ b/src/__tests__/test-cache-service.ts
@@ -9,6 +9,8 @@ import {
 	DelResponse,
 	GetRequest,
 	GetResponse,
+	GetSetRequest,
+	GetSetResponse,
 	KeysRequest,
 	KeysResponse,
 	ListCachesRequest,
@@ -128,6 +130,30 @@ export class TestCacheService {
 					call.request.getValue_asB64()
 				);
 				callback(undefined, new SetResponse().setStatus("set").setMessage("set" + " successfully"));
+			} else {
+				callback(new Error("cache does not exist"), undefined);
+			}
+		},
+		getSet(
+			call: ServerUnaryCall<GetSetRequest, GetSetResponse>,
+			callback: sendUnaryData<GetSetResponse>
+		): void {
+			const cacheName = call.request.getProject() + "_" + call.request.getName();
+			if (TestCacheService.CACHE_MAP.has(cacheName)) {
+				let oldValue = undefined;
+				if (TestCacheService.CACHE_MAP.get(cacheName).has(call.request.getKey())) {
+					oldValue = TestCacheService.CACHE_MAP.get(cacheName).get(call.request.getKey());
+				}
+
+				TestCacheService.CACHE_MAP.get(cacheName).set(
+					call.request.getKey(),
+					call.request.getValue_asB64()
+				);
+				const result = new GetSetResponse().setStatus("set").setMessage("set" + " successfully");
+				if (oldValue !== undefined) {
+					result.setOldValue(oldValue);
+				}
+				callback(undefined, result);
 			} else {
 				callback(new Error("cache does not exist"), undefined);
 			}

--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -787,6 +787,21 @@ describe("rpc tests", () => {
 		expect(keysNew).toContain("k3");
 		expect(keysNew).toContain("k4");
 		expect(keysNew).toHaveLength(3);
+
+		// getset
+		let getSetResp = await c1.getSet("k2", 123_456);
+		expect(getSetResp.old_value).toBe(123);
+
+		getSetResp = await c1.getSet("k2", 123_457);
+		expect(getSetResp.old_value).toBe(123_456);
+
+		// getset for new key
+		try {
+			getSetResp = await c1.getSet("k6", "val6");
+			expect(getSetResp.old_value).toBeUndefined();
+		} catch (error) {
+			console.log(error);
+		}
 	});
 });
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,10 +1,17 @@
-import { CacheDelResponse, CacheGetResponse, CacheSetOptions, CacheSetResponse } from "./types";
+import {
+	CacheDelResponse,
+	CacheGetResponse,
+	CacheGetSetResponse,
+	CacheSetOptions,
+	CacheSetResponse,
+} from "./types";
 import { CacheClient } from "./proto/server/v1/cache_grpc_pb";
 import {
 	DelRequest as ProtoDelRequest,
 	GetRequest as ProtoGetRequest,
 	KeysRequest as ProtoKeysRequest,
 	SetRequest as ProtoSetRequest,
+	GetSetRequest as ProtoGetSetRequest,
 } from "./proto/server/v1/cache_pb";
 import { Utility } from "./utility";
 import { TigrisClientConfig } from "./tigris";
@@ -27,6 +34,9 @@ export class Cache {
 		this._config = config;
 	}
 
+	/**
+	 * returns cache name
+	 */
 	public getCacheName(): string {
 		return this._cacheName;
 	}
@@ -36,6 +46,12 @@ export class Cache {
 	 * @param key
 	 * @param value
 	 * @param options - optionally set params.
+	 * @example
+	 * ```
+	 * const c1 = tigris.GetCache("c1);
+	 * const setResp = await c1.set("k1", "v1");
+	 * console.log(setResp.status);
+	 * ```
 	 */
 	public set(
 		key: string,
@@ -61,9 +77,6 @@ export class Cache {
 			if (options !== undefined && options.xx !== undefined) {
 				req.setXx(options.xx);
 			}
-			if (options !== undefined && options.get !== undefined) {
-				req.setGet(options.get);
-			}
 
 			this._cacheClient.set(req, (error, response) => {
 				if (error) {
@@ -76,8 +89,56 @@ export class Cache {
 	}
 
 	/**
+	 * Sets the key with value. And returns the old value (if exists)
+	 * @param key
+	 * @param value
+	 * @example
+	 * ```
+	 * const c1 = tigris.GetCache("c1);
+	 * const getSetResp = await c1.getSet("k1", "v1");
+	 * console.log(getSetResp.old_value);
+	 * ```
+	 */
+	public getSet(
+		key: string,
+		value: string | number | boolean | object
+	): Promise<CacheGetSetResponse> {
+		return new Promise<CacheGetSetResponse>((resolve, reject) => {
+			const req = new ProtoGetSetRequest()
+				.setProject(this._projectName)
+				.setName(this._cacheName)
+				.setKey(key)
+				.setValue(new TextEncoder().encode(Utility.objToJsonString(value as object)));
+
+			this._cacheClient.getSet(req, (error, response) => {
+				if (error) {
+					reject(error);
+				} else {
+					if (response.getOldValue() !== undefined && response.getOldValue_asU8().length > 0) {
+						resolve(
+							new CacheGetSetResponse(
+								response.getStatus(),
+								response.getMessage(),
+								Utility._base64DecodeToObject(response.getOldValue_asB64(), this._config)
+							)
+						);
+					} else {
+						resolve(new CacheGetSetResponse(response.getStatus(), response.getMessage()));
+					}
+				}
+			});
+		});
+	}
+
+	/**
 	 * get the value for the key, errors if the key doesn't exist or expired
 	 * @param key
+	 * @example
+	 * ```
+	 * const c1 = tigris.GetCache("c1);
+	 * const getResp = await c1.get("k1");
+	 * console.log(getResp.value);
+	 * ```
 	 */
 	public get(key: string): Promise<CacheGetResponse> {
 		return new Promise<CacheGetResponse>((resolve, reject) => {
@@ -101,6 +162,12 @@ export class Cache {
 	/**
 	 * deletes the key
 	 * @param key
+	 * @example
+	 * ```
+	 * const c1 = tigris.GetCache("c1);
+	 * const delResp = await c1.del("k1");
+	 * console.log(delResp.status);
+	 * ```
 	 */
 	public del(key: string): Promise<CacheDelResponse> {
 		return new Promise<CacheDelResponse>((resolve, reject) => {
@@ -120,6 +187,12 @@ export class Cache {
 	/**
 	 * returns an array of keys, complying the pattern
 	 * @param pattern - optional argument to filter keys
+	 * @example
+	 * ```
+	 * const c1 = tigris.GetCache("c1);
+	 * const keys = await c1.keys();
+	 * console.log(keys);
+	 * ```
 	 */
 	public keys(pattern?: string): Promise<string[]> {
 		return new Promise<string[]>((resolve, reject) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,6 +358,21 @@ export class CacheSetResponse extends TigrisResponse {
 	}
 }
 
+export class CacheGetSetResponse extends CacheSetResponse {
+	private readonly _old_value: object;
+
+	constructor(status: string, message: string, old_value?: object) {
+		super(status, message);
+		if (old_value !== undefined) {
+			this._old_value = old_value;
+		}
+	}
+
+	get old_value(): object {
+		return this._old_value;
+	}
+}
+
 export class CacheDelResponse extends TigrisResponse {
 	private readonly _message: string;
 
@@ -373,15 +388,13 @@ export class CacheDelResponse extends TigrisResponse {
 
 export interface CacheSetOptions {
 	// optional ttl in seconds
-	ex: number;
+	ex?: number;
 	// optional ttl in ms
-	px: number;
+	px?: number;
 	// only set if key doesn't exist
-	nx: boolean;
+	nx?: boolean;
 	// only set if key exists
-	xx: boolean;
-	// get the old value as part of response
-	get: boolean;
+	xx?: boolean;
 }
 
 export class CacheGetResponse {


### PR DESCRIPTION
## Describe your changes

- Added getSet method for cache for TypeScript SDK.
- Made set options fields optional.

```
const c1 = tigris.getCache("c1");
await c1.set("k1", "v1");

const getSetResp = c1.getSet("k1", "v2");
console.log(getSetResp.old_value); // "v1"
```
## How best to test these changes

- Unit tested.

## Issue ticket number and link
