### PR TITLE
feat: default timestamp to mark a field with both createdAt or updatedAt

### DIFF
--- a/src/__tests__/fixtures/json-schema/vacationRentals.json
+++ b/src/__tests__/fixtures/json-schema/vacationRentals.json
@@ -53,8 +53,7 @@
 					"maxLength": 2,
 					"default": "US"
 				}
-			},
-			"default": {}
+			}
 		},
 		"verifications": {
 			"type": "object",
@@ -87,20 +86,26 @@
 			},
 			"default": null
 		},
-		"lastSeen": {
+		"availableSince": {
 			"type": "string",
 			"format": "date-time",
 			"default": "now()"
 		},
+		"lastSeen": {
+			"type": "string",
+			"format": "date-time",
+			"createdAt": true,
+			"updatedAt": true
+		},
 		"createdAt": {
 			"type": "string",
 			"format": "date-time",
-			"default": "createdAt"
+			"createdAt": true
 		},
 		"lastModified": {
 			"type": "string",
 			"format": "date-time",
-			"default": "updatedAt"
+			"updatedAt": true
 		},
 		"partnerId": {
 			"type": "string",

--- a/src/__tests__/fixtures/json-schema/vacationRentals.json
+++ b/src/__tests__/fixtures/json-schema/vacationRentals.json
@@ -94,7 +94,7 @@
 		"lastSeen": {
 			"type": "string",
 			"format": "date-time",
-			"createdAt": true,
+			"default": "now()",
 			"updatedAt": true
 		},
 		"createdAt": {

--- a/src/__tests__/fixtures/schema/vacationRentals.ts
+++ b/src/__tests__/fixtures/schema/vacationRentals.ts
@@ -70,13 +70,13 @@ export class VacationRentals {
 	@Field({ default: Generated.NOW })
 	availableSince: Date;
 
-	@Field({ default: Generated.TIMESTAMP })
+	@Field({ default: Generated.NOW, timestamp: "updatedAt" })
 	lastSeen: Date;
 
-	@Field({ default: Generated.CREATED_AT })
+	@Field({ timestamp: "createdAt" })
 	createdAt: Date;
 
-	@Field({ default: Generated.UPDATED_AT })
+	@Field({ timestamp: "updatedAt" })
 	lastModified: Date;
 
 	@Field({ default: Generated.CUID })
@@ -181,15 +181,16 @@ export const VacationsRentalSchema: TigrisSchema<VacationRentals> = {
 	},
 	lastSeen: {
 		type: TigrisDataTypes.DATE_TIME,
-		default: Generated.TIMESTAMP,
+		default: Generated.NOW,
+		timestamp: "updatedAt",
 	},
 	createdAt: {
 		type: TigrisDataTypes.DATE_TIME,
-		default: Generated.CREATED_AT,
+		timestamp: "createdAt",
 	},
 	lastModified: {
 		type: TigrisDataTypes.DATE_TIME,
-		default: Generated.UPDATED_AT,
+		timestamp: "updatedAt",
 	},
 	partnerId: {
 		type: TigrisDataTypes.STRING,

--- a/src/__tests__/fixtures/schema/vacationRentals.ts
+++ b/src/__tests__/fixtures/schema/vacationRentals.ts
@@ -1,5 +1,5 @@
 import { TigrisCollection } from "../../../decorators/tigris-collection";
-import { FieldDefaults, TigrisDataTypes, TigrisSchema } from "../../../types";
+import { Generated, TigrisDataTypes, TigrisSchema } from "../../../types";
 import { PrimaryKey } from "../../../decorators/tigris-primary-key";
 import { Field } from "../../../decorators/tigris-field";
 
@@ -49,7 +49,7 @@ export class VacationRentals {
 	@Field({ default: true })
 	hasWiFi: boolean;
 
-	@Field({ default: {} })
+	@Field()
 	address: Address;
 
 	@Field({ default: { stateId: true } })
@@ -67,19 +67,22 @@ export class VacationRentals {
 	@Field({ elements: TigrisDataTypes.OBJECT, default: undefined })
 	reviews: Array<Object>;
 
-	@Field({ default: FieldDefaults.TIME_NOW })
+	@Field({ default: Generated.NOW })
+	availableSince: Date;
+
+	@Field({ default: Generated.TIMESTAMP })
 	lastSeen: Date;
 
-	@Field({ default: FieldDefaults.TIME_CREATED_AT })
+	@Field({ default: Generated.CREATED_AT })
 	createdAt: Date;
 
-	@Field({ default: FieldDefaults.TIME_UPDATED_AT })
+	@Field({ default: Generated.UPDATED_AT })
 	lastModified: Date;
 
-	@Field({ default: FieldDefaults.AUTO_CUID })
+	@Field({ default: Generated.CUID })
 	partnerId: string;
 
-	@Field(TigrisDataTypes.UUID, { default: FieldDefaults.AUTO_UUID })
+	@Field(TigrisDataTypes.UUID, { default: Generated.UUID })
 	referralId: string;
 }
 /********************************** END **************************************/
@@ -142,7 +145,6 @@ export const VacationsRentalSchema: TigrisSchema<VacationRentals> = {
 				maxLength: 2,
 			},
 		},
-		default: {},
 	},
 	verifications: {
 		type: TigrisDataTypes.OBJECT,
@@ -173,24 +175,28 @@ export const VacationsRentalSchema: TigrisSchema<VacationRentals> = {
 		},
 		default: undefined,
 	},
+	availableSince: {
+		type: TigrisDataTypes.DATE_TIME,
+		default: Generated.NOW,
+	},
 	lastSeen: {
 		type: TigrisDataTypes.DATE_TIME,
-		default: FieldDefaults.TIME_NOW,
+		default: Generated.TIMESTAMP,
 	},
 	createdAt: {
 		type: TigrisDataTypes.DATE_TIME,
-		default: FieldDefaults.TIME_CREATED_AT,
+		default: Generated.CREATED_AT,
 	},
 	lastModified: {
 		type: TigrisDataTypes.DATE_TIME,
-		default: FieldDefaults.TIME_UPDATED_AT,
+		default: Generated.UPDATED_AT,
 	},
 	partnerId: {
 		type: TigrisDataTypes.STRING,
-		default: FieldDefaults.AUTO_CUID,
+		default: Generated.CUID,
 	},
 	referralId: {
 		type: TigrisDataTypes.UUID,
-		default: FieldDefaults.AUTO_UUID,
+		default: Generated.UUID,
 	},
 };

--- a/src/schema/decorated-schema-processor.ts
+++ b/src/schema/decorated-schema-processor.ts
@@ -70,6 +70,10 @@ export class DecoratedSchemaProcessor {
 			if (field.schemaFieldOptions && "default" in field.schemaFieldOptions) {
 				schema[key].default = field.schemaFieldOptions.default;
 			}
+			// set "timestamp" value for field,  if any
+			if (field.schemaFieldOptions && "timestamp" in field.schemaFieldOptions) {
+				schema[key].timestamp = field.schemaFieldOptions.timestamp;
+			}
 		}
 		return schema;
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -445,12 +445,6 @@ export enum UpdateFieldsOperator {
 
 export type FieldTypes = string | number | boolean | bigint | BigInteger;
 
-export type LogicalFilter<T> = {
-	op: LogicalOperator;
-	selectorFilters?: Array<SelectorFilter<T> | Selector<T>>;
-	logicalFilters?: Array<LogicalFilter<T>>;
-};
-
 export type ReadFields = {
 	include?: Array<string>;
 	exclude?: Array<string>;
@@ -545,12 +539,13 @@ export enum TigrisDataTypes {
 	OBJECT = "object",
 }
 
-export enum FieldDefaults {
-	TIME_UPDATED_AT = "updatedAt",
-	TIME_CREATED_AT = "createdAt",
-	TIME_NOW = "now()",
-	AUTO_CUID = "cuid()",
-	AUTO_UUID = "uuid()",
+export enum Generated {
+	UPDATED_AT = "updatedAt",
+	CREATED_AT = "createdAt",
+	TIMESTAMP = "timestamp",
+	NOW = "now()",
+	CUID = "cuid()",
+	UUID = "uuid()",
 }
 
 export type TigrisFieldOptions = {
@@ -562,7 +557,7 @@ export type TigrisFieldOptions = {
 	 * Default
 	 */
 	default?:
-		| FieldDefaults
+		| Generated
 		| number
 		| bigint
 		| string
@@ -638,5 +633,11 @@ export type SelectorFilter<T> = Partial<{
 	op?: SelectorFilterOperator;
 	fields: Selector<T>;
 }>;
+
+export type LogicalFilter<T> = {
+	op: LogicalOperator;
+	selectorFilters?: Array<SelectorFilter<T> | Selector<T>>;
+	logicalFilters?: Array<LogicalFilter<T>>;
+};
 
 export type Filter<T> = SelectorFilter<T> | LogicalFilter<T> | Selector<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -539,14 +539,16 @@ export enum TigrisDataTypes {
 	OBJECT = "object",
 }
 
+/**
+ * DB generated values for the schema fields
+ */
 export enum Generated {
-	UPDATED_AT = "updatedAt",
-	CREATED_AT = "createdAt",
-	TIMESTAMP = "timestamp",
 	NOW = "now()",
 	CUID = "cuid()",
 	UUID = "uuid()",
 }
+
+export type AutoTimestamp = "createdAt" | "updatedAt";
 
 export type TigrisFieldOptions = {
 	/**
@@ -554,7 +556,7 @@ export type TigrisFieldOptions = {
 	 */
 	maxLength?: number;
 	/**
-	 * Default
+	 * Default value for the schema field
 	 */
 	default?:
 		| Generated
@@ -565,6 +567,11 @@ export type TigrisFieldOptions = {
 		| Date
 		| Array<unknown>
 		| Record<string, unknown>;
+
+	/**
+	 * Let DB generate values for `Date` type of fields
+	 */
+	timestamp?: AutoTimestamp;
 };
 
 export type TigrisSchema<T extends TigrisCollectionType> = {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -4,7 +4,6 @@ import { Session } from "./session";
 
 import {
 	DeleteQueryOptions,
-	Generated,
 	Filter,
 	FindQueryOptions,
 	LogicalFilter,
@@ -333,6 +332,7 @@ export const Utility = {
 				thisProperty = this._getArrayBlock(schema[property], pkeyMap, keyMap);
 			}
 			properties[property] = thisProperty;
+
 			// 'default' values for schema fields, if any
 			if ("default" in schema[property]) {
 				switch (schema[property].default) {
@@ -340,19 +340,14 @@ export const Utility = {
 						// eslint-disable-next-line unicorn/no-null
 						thisProperty["default"] = null;
 						break;
-					case Generated.UPDATED_AT:
-						thisProperty[Generated.UPDATED_AT] = true;
-						break;
-					case Generated.CREATED_AT:
-						thisProperty[Generated.CREATED_AT] = true;
-						break;
-					case Generated.TIMESTAMP:
-						thisProperty[Generated.CREATED_AT] = true;
-						thisProperty[Generated.UPDATED_AT] = true;
-						break;
 					default:
 						thisProperty["default"] = schema[property].default;
 				}
+			}
+
+			// 'timestamp' values for schema fields
+			if ("timestamp" in schema[property]) {
+				thisProperty[schema[property].timestamp] = true;
 			}
 		}
 		return properties;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -4,6 +4,8 @@ import { Session } from "./session";
 
 import {
 	DeleteQueryOptions,
+	Generated,
+	Filter,
 	FindQueryOptions,
 	LogicalFilter,
 	LogicalOperator,
@@ -46,7 +48,7 @@ export const Utility = {
 		return new TextDecoder().decode(input);
 	},
 
-	filterToString<T>(filter: SelectorFilter<T> | LogicalFilter<T> | Selector<T>): string {
+	filterToString<T>(filter: Filter<T>): string {
 		if (
 			Object.prototype.hasOwnProperty.call(filter, "op") &&
 			(filter["op"] === LogicalOperator.AND || filter["op"] === LogicalOperator.OR)
@@ -333,9 +335,24 @@ export const Utility = {
 			properties[property] = thisProperty;
 			// 'default' values for schema fields, if any
 			if ("default" in schema[property]) {
-				thisProperty["default"] =
-					// eslint-disable-next-line unicorn/no-null
-					schema[property].default == undefined ? null : schema[property].default;
+				switch (schema[property].default) {
+					case undefined:
+						// eslint-disable-next-line unicorn/no-null
+						thisProperty["default"] = null;
+						break;
+					case Generated.UPDATED_AT:
+						thisProperty[Generated.UPDATED_AT] = true;
+						break;
+					case Generated.CREATED_AT:
+						thisProperty[Generated.CREATED_AT] = true;
+						break;
+					case Generated.TIMESTAMP:
+						thisProperty[Generated.CREATED_AT] = true;
+						thisProperty[Generated.UPDATED_AT] = true;
+						break;
+					default:
+						thisProperty["default"] = schema[property].default;
+				}
 			}
 		}
 		return properties;


### PR DESCRIPTION
## Describe your changes
- Introduced a way to mark a field both with `createdAt` and `updatedAt`
- Renamed the generator functions under `Generated` enum

## How best to test these changes
- unit tests

## Issue ticket number and link
TIG-810
