### PR TITLE
feat: Cache keys streams response

### DIFF
--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -773,12 +773,15 @@ describe("rpc tests", () => {
 		await c1.set("k4", { a: "b", n: 12 });
 		expect((await c1.get("k4")).value).toEqual({ a: "b", n: 12 });
 
-		const keys = await c1.keys();
+		const keysArrays = await c1.keys().toArray();
+		const keys: Array<string> = new Array<string>();
+		keysArrays.forEach((keysArray) => keysArray.forEach((key) => keys.push(key)));
+
+		expect(keys).toHaveLength(4);
 		expect(keys).toContain("k1");
 		expect(keys).toContain("k2");
 		expect(keys).toContain("k3");
 		expect(keys).toContain("k4");
-		expect(keys).toHaveLength(4);
 
 		await c1.del("k1");
 		let errored = false;
@@ -791,11 +794,13 @@ describe("rpc tests", () => {
 		expect(errored).toBe(true);
 
 		// k1 is deleted
-		const keysNew = await c1.keys();
+		const keysNewArray = await c1.keys().toArray();
+		const keysNew: Array<string> = new Array<string>();
+		keysNewArray.forEach((keysArray) => keysArray.forEach((key) => keysNew.push(key)));
+		expect(keysNew).toHaveLength(3);
 		expect(keysNew).toContain("k2");
 		expect(keysNew).toContain("k3");
 		expect(keysNew).toContain("k4");
-		expect(keysNew).toHaveLength(3);
 
 		// getset
 		let getSetResp = await c1.getSet("k2", 123_456);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -9,12 +9,13 @@ import { CacheClient } from "./proto/server/v1/cache_grpc_pb";
 import {
 	DelRequest as ProtoDelRequest,
 	GetRequest as ProtoGetRequest,
+	GetSetRequest as ProtoGetSetRequest,
 	KeysRequest as ProtoKeysRequest,
 	SetRequest as ProtoSetRequest,
-	GetSetRequest as ProtoGetSetRequest,
 } from "./proto/server/v1/cache_pb";
 import { Utility } from "./utility";
 import { TigrisClientConfig } from "./tigris";
+import { CacheKeysCursor, CacheKeysCursorInitializer } from "./consumables/cursor";
 
 export class Cache {
 	private readonly _projectName: string;
@@ -190,23 +191,19 @@ export class Cache {
 	 * @example
 	 * ```
 	 * const c1 = tigris.GetCache("c1);
-	 * const keys = await c1.keys();
-	 * console.log(keys);
+	 * const keysCursor = await c1.keys();
+	 * for await (const keys of keysCursor) {
+	 *	console.log(keys);
+	 * }
 	 * ```
 	 */
-	public keys(pattern?: string): Promise<string[]> {
-		return new Promise<string[]>((resolve, reject) => {
-			const req = new ProtoKeysRequest().setProject(this._projectName).setName(this._cacheName);
-			if (pattern !== undefined) {
-				req.setPattern(pattern);
-			}
-			this._cacheClient.keys(req, (error, response) => {
-				if (error) {
-					reject(error);
-				} else {
-					resolve(response.getKeysList());
-				}
-			});
-		});
+	public keys(pattern?: string): CacheKeysCursor {
+		const req = new ProtoKeysRequest().setProject(this._projectName).setName(this._cacheName);
+		if (pattern !== undefined) {
+			req.setPattern(pattern);
+		}
+		this._cacheClient.keys(req);
+		const initializer = new CacheKeysCursorInitializer(this._cacheClient, req);
+		return new CacheKeysCursor(initializer);
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -349,6 +349,7 @@ export class CacheMetadata {
 		return this._name;
 	}
 }
+
 export class ListCachesResponse {
 	private readonly _caches: CacheMetadata[];
 


### PR DESCRIPTION
## Describe your changes
Cache operation to list all keys returns Cursor and allows client to iterate on it in streaming manner.

### Example usage
```
const c1 = tigris.GetCache("c1);
const keysCursor = await c1.keys();
for await (const keys of keysCursor) {
        // keys is of type Array<String>
	console.log(keys);
}
```
## How best to test these changes
Mocked integration tests are included in this PR.

## Issue ticket number and link
