### PR TITLE
refactor: Tigris operations to use enums for Status

### DIFF
--- a/src/__tests__/test-service.ts
+++ b/src/__tests__/test-service.ts
@@ -259,7 +259,6 @@ export class TestTigrisService {
 			assert(call.request.getBranch() === TestTigrisService.ExpectedBranch);
 
 			const reply: CommitTransactionResponse = new CommitTransactionResponse();
-			reply.setStatus("committed-test");
 			callback(undefined, reply);
 		},
 		createProject(
@@ -604,7 +603,6 @@ export class TestTigrisService {
 			assert(call.request.getBranch() === TestTigrisService.ExpectedBranch);
 
 			const reply: RollbackTransactionResponse = new RollbackTransactionResponse();
-			reply.setStatus("rollback-test");
 			callback(undefined, reply);
 		},
 		update(

--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -26,6 +26,7 @@ import { SearchIterator } from "../consumables/search-iterator";
 import { CacheService } from "../proto/server/v1/cache_grpc_pb";
 import { DatabaseBranchError } from "../error";
 import { Status } from "@grpc/grpc-js/build/src/constants";
+import { Status as TigrisStatus } from "../constants";
 
 describe("rpc tests", () => {
 	let server: Server;
@@ -326,7 +327,7 @@ describe("rpc tests", () => {
 			},
 		});
 		updatePromise.then((value) => {
-			expect(value.status).toBe('updated: {"id":1}, {"$set":{"title":"New Title"}}');
+			expect(value.status).toBe(TigrisStatus.Updated);
 			expect(value.modifiedCount).toBe(1);
 		});
 		return updatePromise;
@@ -569,7 +570,7 @@ describe("rpc tests", () => {
 		beginTxPromise.then((session) => {
 			const commitTxResponse = session.commit();
 			commitTxResponse.then((value) => {
-				expect(value.status).toBe("committed-test");
+				expect(value.status).toBe(TigrisStatus.Success);
 			});
 			return beginTxPromise;
 		});
@@ -582,7 +583,7 @@ describe("rpc tests", () => {
 		beginTxPromise.then((session) => {
 			const rollbackTransactionResponsePromise = session.rollback();
 			rollbackTransactionResponsePromise.then((value) => {
-				expect(value.status).toBe("rollback-test");
+				expect(value.status).toBe(TigrisStatus.Success);
 			});
 		});
 		return beginTxPromise;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -82,7 +82,7 @@ export class Cache {
 				if (error) {
 					reject(error);
 				} else {
-					resolve(new CacheSetResponse(response.getStatus(), response.getMessage()));
+					resolve(new CacheSetResponse(response.getMessage()));
 				}
 			});
 		});
@@ -117,13 +117,12 @@ export class Cache {
 					if (response.getOldValue() !== undefined && response.getOldValue_asU8().length > 0) {
 						resolve(
 							new CacheGetSetResponse(
-								response.getStatus(),
 								response.getMessage(),
 								Utility._base64DecodeToObject(response.getOldValue_asB64(), this._config)
 							)
 						);
 					} else {
-						resolve(new CacheGetSetResponse(response.getStatus(), response.getMessage()));
+						resolve(new CacheGetSetResponse(response.getMessage()));
 					}
 				}
 			});

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -226,7 +226,7 @@ export class Collection<T extends TigrisCollectionType> implements ICollection {
 						response.getMetadata().getCreatedAt(),
 						response.getMetadata().getUpdatedAt()
 					);
-					resolve(new UpdateResponse(response.getStatus(), response.getModifiedCount(), metadata));
+					resolve(new UpdateResponse(response.getModifiedCount(), metadata));
 				}
 			});
 		});
@@ -354,7 +354,7 @@ export class Collection<T extends TigrisCollectionType> implements ICollection {
 						response.getMetadata().getCreatedAt(),
 						response.getMetadata().getUpdatedAt()
 					);
-					resolve(new DeleteResponse(response.getStatus(), metadata));
+					resolve(new DeleteResponse(metadata));
 				}
 			});
 		});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+export enum Status {
+	Created = "created",
+	Updated = "updated",
+	Deleted = "deleted",
+	Dropped = "dropped",
+	Success = "success",
+	Set = "set",
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -300,7 +300,7 @@ export class DB {
 					if (error) {
 						reject(error);
 					} else {
-						resolve(new DropCollectionResponse(response.getStatus(), response.getMessage()));
+						resolve(new DropCollectionResponse(response.getMessage()));
 					}
 				}
 			);
@@ -399,7 +399,7 @@ export class DB {
 						// user code successful
 						const commitResponse: CommitTransactionResponse = await session.commit();
 						if (commitResponse) {
-							resolve(new TransactionResponse("transaction successful"));
+							resolve(new TransactionResponse());
 						}
 					} catch (error) {
 						// failed to run user code

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from "./session";
 export * from "./tigris";
 export * from "./types";
 export * from "./search/types";
+export * from "./constants";
 export { Field } from "./decorators/tigris-field";
 export { PrimaryKey } from "./decorators/tigris-primary-key";
 export { TigrisCollection } from "./decorators/tigris-collection";

--- a/src/session.ts
+++ b/src/session.ts
@@ -52,7 +52,7 @@ export class Session {
 				if (error) {
 					reject(error);
 				} else {
-					resolve(new CommitTransactionResponse(response.getStatus()));
+					resolve(new CommitTransactionResponse());
 				}
 			});
 		});
@@ -70,7 +70,7 @@ export class Session {
 					if (error) {
 						reject(error);
 					} else {
-						resolve(new RollbackTransactionResponse(response.getStatus()));
+						resolve(new RollbackTransactionResponse());
 					}
 				}
 			);

--- a/src/tigris.ts
+++ b/src/tigris.ts
@@ -300,7 +300,7 @@ export class Tigris {
 					if (error) {
 						reject(error);
 					} else {
-						resolve(new DeleteCacheResponse(response.getStatus(), response.getMessage()));
+						resolve(new DeleteCacheResponse(response.getMessage()));
 					}
 				}
 			);

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import {
 	CreateBranchResponse as ProtoCreateBranchResponse,
 	DeleteBranchResponse as ProtoDeleteBranchResponse,
 } from "./proto/server/v1/api_pb";
+import { Status } from "./constants";
 
 export class DatabaseInfo {
 	private readonly _name: string;
@@ -48,23 +49,16 @@ export class DatabaseOptions {}
 
 export class CollectionOptions {}
 
-export class TigrisResponse {
-	private readonly _status: string;
-
-	constructor(status: string) {
-		this._status = status;
-	}
-
-	get status(): string {
-		return this._status;
-	}
+export interface TigrisResponse {
+	status: Status;
+	message?: string;
 }
 
-export class CreateBranchResponse extends TigrisResponse {
+export class CreateBranchResponse implements TigrisResponse {
+	status: Status = Status.Created;
 	private readonly _message: string;
 
-	constructor(status: string, message: string) {
-		super(status);
+	constructor(message: string) {
 		this._message = message;
 	}
 
@@ -73,14 +67,14 @@ export class CreateBranchResponse extends TigrisResponse {
 	}
 
 	static from(response: ProtoCreateBranchResponse): CreateBranchResponse {
-		return new this(response.getStatus(), response.getMessage());
+		return new this(response.getMessage());
 	}
 }
 
-export class DeleteBranchResponse extends TigrisResponse {
+export class DeleteBranchResponse implements TigrisResponse {
+	status: Status = Status.Deleted;
 	private readonly _message: string;
-	constructor(status: string, message: string) {
-		super(status);
+	constructor(message: string) {
 		this._message = message;
 	}
 
@@ -89,21 +83,16 @@ export class DeleteBranchResponse extends TigrisResponse {
 	}
 
 	static from(response: ProtoDeleteBranchResponse): DeleteBranchResponse {
-		return new this(response.getStatus(), response.getMessage());
+		return new this(response.getMessage());
 	}
 }
 
-export class DropCollectionResponse {
-	private readonly _status: string;
+export class DropCollectionResponse implements TigrisResponse {
+	status: Status = Status.Dropped;
 	private readonly _message: string;
 
-	constructor(status: string, message: string) {
-		this._status = status;
+	constructor(message: string) {
 		this._message = message;
-	}
-
-	get status(): string {
-		return this._status;
 	}
 
 	get message(): string {
@@ -181,11 +170,15 @@ export class DMLMetadata {
 	}
 }
 
-export class DMLResponse extends TigrisResponse {
+export interface DMLResponse {
+	metadata: DMLMetadata;
+}
+
+export class DeleteResponse implements TigrisResponse, DMLResponse {
+	status: Status = Status.Deleted;
 	private readonly _metadata: DMLMetadata;
 
-	constructor(status: string, metadata: DMLMetadata) {
-		super(status);
+	constructor(metadata: DMLMetadata) {
 		this._metadata = metadata;
 	}
 
@@ -194,21 +187,22 @@ export class DMLResponse extends TigrisResponse {
 	}
 }
 
-export class DeleteResponse extends DMLResponse {
-	constructor(status: string, metadata: DMLMetadata) {
-		super(status, metadata);
-	}
-}
-
-export class UpdateResponse extends DMLResponse {
+export class UpdateResponse implements TigrisResponse, DMLResponse {
+	status: Status = Status.Updated;
+	private readonly _metadata: DMLMetadata;
 	private readonly _modifiedCount: number;
-	constructor(status: string, modifiedCount: number, metadata: DMLMetadata) {
-		super(status, metadata);
+
+	constructor(modifiedCount: number, metadata: DMLMetadata) {
 		this._modifiedCount = modifiedCount;
+		this._metadata = metadata;
 	}
 
 	get modifiedCount(): number {
 		return this._modifiedCount;
+	}
+
+	get metadata(): DMLMetadata {
+		return this._metadata;
 	}
 }
 
@@ -320,22 +314,16 @@ export class FindQueryOptions {
 
 export class TransactionOptions {}
 
-export class CommitTransactionResponse extends TigrisResponse {
-	constructor(status: string) {
-		super(status);
-	}
+export class CommitTransactionResponse implements TigrisResponse {
+	status: Status = Status.Success;
 }
 
-export class RollbackTransactionResponse extends TigrisResponse {
-	public constructor(status: string) {
-		super(status);
-	}
+export class RollbackTransactionResponse implements TigrisResponse {
+	status: Status = Status.Success;
 }
 
-export class TransactionResponse extends TigrisResponse {
-	constructor(status: string) {
-		super(status);
-	}
+export class TransactionResponse implements TigrisResponse {
+	status: Status = Status.Success;
 }
 
 export class CacheMetadata {
@@ -361,11 +349,11 @@ export class ListCachesResponse {
 	}
 }
 
-export class DeleteCacheResponse extends TigrisResponse {
+export class DeleteCacheResponse implements TigrisResponse {
+	status: Status = Status.Deleted;
 	private readonly _message: string;
 
-	constructor(status: string, message: string) {
-		super(status);
+	constructor(message: string) {
 		this._message = message;
 	}
 
@@ -374,11 +362,11 @@ export class DeleteCacheResponse extends TigrisResponse {
 	}
 }
 
-export class CacheSetResponse extends TigrisResponse {
+export class CacheSetResponse implements TigrisResponse {
+	status: Status = Status.Set;
 	private readonly _message: string;
 
-	constructor(status: string, message: string) {
-		super(status);
+	constructor(message: string) {
 		this._message = message;
 	}
 
@@ -390,8 +378,8 @@ export class CacheSetResponse extends TigrisResponse {
 export class CacheGetSetResponse extends CacheSetResponse {
 	private readonly _old_value: object;
 
-	constructor(status: string, message: string, old_value?: object) {
-		super(status, message);
+	constructor(message: string, old_value?: object) {
+		super(message);
 		if (old_value !== undefined) {
 			this._old_value = old_value;
 		}
@@ -402,11 +390,11 @@ export class CacheGetSetResponse extends CacheSetResponse {
 	}
 }
 
-export class CacheDelResponse extends TigrisResponse {
+export class CacheDelResponse implements TigrisResponse {
+	status: Status = Status.Deleted;
 	private readonly _message: string;
 
 	constructor(status: string, message: string) {
-		super(status);
 		this._message = message;
 	}
 


### PR DESCRIPTION
Returning response statuses for users to assert against:

```
DeleteResponse:
      status: "deleted"

UpdateResponse:
       status: "updated"

CreateResponse:
       status: "created"
```

## Alternatives (need feedback)

### 1. Boolean in responses
Another option is to replace `status: Status` with `success: boolean` for easy assertion. Opinions?
- Essentially these operations can have a `success: true`:
![Screenshot 2023-01-17 at 9 07 23 AM](https://user-images.githubusercontent.com/2469198/212965290-fca361f1-6a88-4d55-abf2-d9feeda7ad69.png)
- How will it work if updateMany() succeeds partially and returns num of updated rows?

### 2. Promise<boolean> from api
- DDL operations  (drop collection. create/delete branch etc.) or cache.set() can instead return a `Promise<boolean>`. Having them return an object later would be a breaking change.

## How best to test these changes
- Tests
