### PR TITLE
feat: Sync `getDatabase()` call

### DIFF
--- a/src/__tests__/consumables/cursor.spec.ts
+++ b/src/__tests__/consumables/cursor.spec.ts
@@ -13,7 +13,7 @@ describe("FindCursor", () => {
 	const SERVER_PORT = 5003;
 	let db: DB;
 
-	beforeAll(async () => {
+	beforeAll(() => {
 		server = new Server();
 		TestTigrisService.reset();
 		server.addService(TigrisService, TestService.handler.impl);
@@ -35,9 +35,7 @@ describe("FindCursor", () => {
 			projectName: "db3",
 			branch: TestTigrisService.ExpectedBranch,
 		});
-		const dbPromise = tigris.getDatabase();
-		db = await dbPromise;
-		return dbPromise;
+		db = tigris.getDatabase();
 	});
 
 	beforeEach(() => {

--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -1,5 +1,5 @@
 import { Server, ServerCredentials, ServiceError } from "@grpc/grpc-js";
-import { TigrisClient, TigrisService } from "../proto/server/v1/api_grpc_pb";
+import { TigrisService } from "../proto/server/v1/api_grpc_pb";
 import TestService, { Branch, TestTigrisService } from "./test-service";
 import TestServiceCache, { TestCacheService } from "./test-cache-service";
 
@@ -24,7 +24,7 @@ import { PrimaryKey } from "../decorators/tigris-primary-key";
 import { Field } from "../decorators/tigris-field";
 import { SearchIterator } from "../consumables/search-iterator";
 import { CacheService } from "../proto/server/v1/cache_grpc_pb";
-import { DatabaseBranchError } from "../error";
+import { BranchNotFoundError } from "../error";
 import { Status } from "@grpc/grpc-js/build/src/constants";
 import { Status as TigrisStatus } from "../constants";
 
@@ -63,15 +63,15 @@ describe("rpc tests", () => {
 		done();
 	});
 
-	it("getDatabase", async () => {
+	it("getDatabase", () => {
 		const tigris = new Tigris(testConfig);
-		const db1 = await tigris.getDatabase();
-		expect(db1.db).toBe("db1");
+		const db1 = tigris.getDatabase();
+		expect(db1.name).toBe("db1");
 	});
 
 	it("listCollections1", async () => {
 		const tigris = new Tigris(testConfig);
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 
 		const listCollectionPromise = db1.listCollections();
 		listCollectionPromise.then((value) => {
@@ -87,7 +87,7 @@ describe("rpc tests", () => {
 
 	it("listCollections2", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 
 		const listCollectionPromise = db1.listCollections();
 		listCollectionPromise.then((value) => {
@@ -103,7 +103,7 @@ describe("rpc tests", () => {
 
 	it("describeDatabase", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 
 		const databaseDescriptionPromise = db1.describe();
 		databaseDescriptionPromise.then((value) => {
@@ -119,7 +119,7 @@ describe("rpc tests", () => {
 
 	it("dropCollection", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 
 		const dropCollectionPromise = db1.dropCollection("db3_coll_2");
 		dropCollectionPromise.then((value) => {
@@ -131,14 +131,14 @@ describe("rpc tests", () => {
 
 	it("getCollection", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const books = db1.getCollection<IBook>("books");
 		expect(books.collectionName).toBe("books");
 	});
 
 	it("insert", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const insertionPromise = db1.getCollection<IBook>("books").insertOne({
 			author: "author name",
 			id: 0,
@@ -153,7 +153,7 @@ describe("rpc tests", () => {
 
 	it("insert2", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const insertionPromise = db1.getCollection<IBook2>("books").insertOne({
 			id: 0,
 			title: "science book",
@@ -170,7 +170,7 @@ describe("rpc tests", () => {
 
 	it("insert_multi_pk", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const insertionPromise = db1.getCollection<IBookMPK>("books-multi-pk").insertOne({
 			id: 0,
 			id2: 0,
@@ -189,7 +189,7 @@ describe("rpc tests", () => {
 
 	it("insert_multi_pk_many", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const insertionPromise = db1.getCollection<IBookMPK>("books-multi-pk").insertMany([
 			{
 				id: 0,
@@ -222,7 +222,7 @@ describe("rpc tests", () => {
 
 	it("insertWithOptionalField", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const randomNumber: number = Math.floor(Math.random() * 100);
 		// pass the random number in author field. mock server reads author and sets as the
 		// primaryKey field.
@@ -239,7 +239,7 @@ describe("rpc tests", () => {
 
 	it("insertOrReplace", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const insertOrReplacePromise = db1.getCollection<IBook>("books").insertOrReplaceOne({
 			author: "author name",
 			id: 0,
@@ -254,7 +254,7 @@ describe("rpc tests", () => {
 
 	it("insertOrReplaceWithOptionalField", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const randomNumber: number = Math.floor(Math.random() * 100);
 		// pass the random number in author field. mock server reads author and sets as the
 		// primaryKey field.
@@ -273,7 +273,7 @@ describe("rpc tests", () => {
 
 	it("delete", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const deletionPromise = db1.getCollection<IBook>(IBook).deleteMany({
 			filter: { id: 1 },
 		});
@@ -287,7 +287,7 @@ describe("rpc tests", () => {
 
 	it("deleteOne", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const collection = (await tigris.getDatabase()).getCollection<IBook>("books");
+		const collection = tigris.getDatabase().getCollection<IBook>("books");
 		const spyCollection = spy(collection);
 
 		const expectedFilter = { id: 1 };
@@ -311,7 +311,7 @@ describe("rpc tests", () => {
 
 	it("update", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const updatePromise = db1.getCollection<IBook>("books").updateMany({
 			filter: {
 				op: SelectorFilterOperator.EQ,
@@ -335,7 +335,7 @@ describe("rpc tests", () => {
 
 	it("updateOne", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const collection = (await tigris.getDatabase()).getCollection<IBook>("books");
+		const collection = tigris.getDatabase().getCollection<IBook>("books");
 		const spyCollection = spy(collection);
 
 		const expectedFilter = { id: 1 };
@@ -366,7 +366,7 @@ describe("rpc tests", () => {
 
 	it("readOne", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const readOnePromise = db1.getCollection<IBook>("books").findOne({
 			filter: {
 				op: SelectorFilterOperator.EQ,
@@ -387,7 +387,7 @@ describe("rpc tests", () => {
 
 	it("readOneRecordNotFound", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const readOnePromise = db1.getCollection<IBook>("books").findOne({
 			filter: {
 				op: SelectorFilterOperator.EQ,
@@ -404,7 +404,7 @@ describe("rpc tests", () => {
 
 	it("readOneWithLogicalFilter", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db1 = await tigris.getDatabase();
+		const db1 = tigris.getDatabase();
 		const readOnePromise: Promise<IBook | void> = db1.getCollection<IBook>("books").findOne({
 			filter: {
 				op: LogicalOperator.AND,
@@ -438,7 +438,7 @@ describe("rpc tests", () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
 
 		it("with filter using for await on cursor", async () => {
-			const db = await tigris.getDatabase();
+			const db = tigris.getDatabase();
 			const cursor = db.getCollection<IBook>("books").findMany({
 				filter: {
 					op: SelectorFilterOperator.EQ,
@@ -457,7 +457,7 @@ describe("rpc tests", () => {
 		});
 
 		it("finds all and retrieves results as array", async () => {
-			const db = await tigris.getDatabase();
+			const db = tigris.getDatabase();
 			const cursor = db.getCollection<IBook>("books").findMany();
 			const booksPromise = cursor.toArray();
 
@@ -466,7 +466,7 @@ describe("rpc tests", () => {
 		});
 
 		it("finds all and streams through results", async () => {
-			const db = await tigris.getDatabase();
+			const db = tigris.getDatabase();
 			const cursor = db.getCollection<IBook>("books").findMany();
 			const booksIterator = cursor.stream();
 
@@ -479,7 +479,7 @@ describe("rpc tests", () => {
 		});
 
 		it("throws an error", async () => {
-			const db = await tigris.getDatabase();
+			const db = tigris.getDatabase();
 			const cursor = db.getCollection<IBook>("books").findMany({
 				filter: {
 					op: SelectorFilterOperator.EQ,
@@ -507,7 +507,7 @@ describe("rpc tests", () => {
 			const pageNumber = 2;
 
 			it("returns a promise", async () => {
-				const db = await tigris.getDatabase();
+				const db = tigris.getDatabase();
 				const query: SearchQuery<IBook> = {
 					q: "philosophy",
 					facets: {
@@ -529,7 +529,7 @@ describe("rpc tests", () => {
 
 		describe("without explicit page number", () => {
 			it("returns an iterator", async () => {
-				const db = await tigris.getDatabase();
+				const db = tigris.getDatabase();
 				const query: SearchQuery<IBook> = {
 					q: "philosophy",
 					facets: {
@@ -554,7 +554,7 @@ describe("rpc tests", () => {
 
 	it("beginTx", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db3 = await tigris.getDatabase();
+		const db3 = tigris.getDatabase();
 		const beginTxPromise = db3.beginTransaction();
 		beginTxPromise.then((value) => {
 			expect(value.id).toBe("id-test");
@@ -565,7 +565,7 @@ describe("rpc tests", () => {
 
 	it("commitTx", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db3 = await tigris.getDatabase();
+		const db3 = tigris.getDatabase();
 		const beginTxPromise = db3.beginTransaction();
 		beginTxPromise.then((session) => {
 			const commitTxResponse = session.commit();
@@ -578,7 +578,7 @@ describe("rpc tests", () => {
 
 	it("rollbackTx", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db3 = await tigris.getDatabase();
+		const db3 = tigris.getDatabase();
 		const beginTxPromise = db3.beginTransaction();
 		beginTxPromise.then((session) => {
 			const rollbackTransactionResponsePromise = session.rollback();
@@ -591,7 +591,7 @@ describe("rpc tests", () => {
 
 	it("transact", async () => {
 		const tigris = new Tigris({ projectName: "test-tx", ...testConfig });
-		const txDB = await tigris.getDatabase();
+		const txDB = tigris.getDatabase();
 		const books = txDB.getCollection<IBook>("books");
 		return txDB.transact((tx) => {
 			books
@@ -658,7 +658,7 @@ describe("rpc tests", () => {
 
 	it("createOrUpdateCollections", async () => {
 		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
-		const db3 = await tigris.getDatabase();
+		const db3 = tigris.getDatabase();
 		const bookSchema: TigrisSchema<IBook> = {
 			id: {
 				type: TigrisDataTypes.INT64,
@@ -819,7 +819,7 @@ describe("rpc tests", () => {
 
 		it("creates a new branch", async () => {
 			expect.hasAssertions();
-			const db = await tigris.getDatabase();
+			const db = tigris.getDatabase();
 			const createResp = db.createBranch("staging");
 
 			return createResp.then((r) => expect(r.status).toBe("created"));
@@ -827,7 +827,7 @@ describe("rpc tests", () => {
 
 		it("fails to create existing branch", async () => {
 			expect.assertions(2);
-			const db = await tigris.getDatabase();
+			const db = tigris.getDatabase();
 			const createResp = db.createBranch(Branch.Existing);
 			createResp.catch((r) => {
 				expect((r as ServiceError).code).toEqual(Status.ALREADY_EXISTS);
@@ -838,7 +838,7 @@ describe("rpc tests", () => {
 
 		it("deletes a branch successfully", async () => {
 			expect.hasAssertions();
-			const db = await tigris.getDatabase();
+			const db = tigris.getDatabase();
 			const deleteResp = db.deleteBranch("staging");
 
 			return deleteResp.then((r) => expect(r.status).toBe("deleted"));
@@ -846,7 +846,7 @@ describe("rpc tests", () => {
 
 		it("fails to delete a branch if not existing already", async () => {
 			expect.assertions(2);
-			const db = await tigris.getDatabase();
+			const db = tigris.getDatabase();
 			const deleteResp = db.deleteBranch(Branch.NotFound);
 			deleteResp.catch((r) => {
 				expect((r as ServiceError).code).toEqual(Status.NOT_FOUND);
@@ -856,7 +856,7 @@ describe("rpc tests", () => {
 		});
 	});
 
-	describe("initializeDB() tests", () => {
+	describe("initializeBranch()", () => {
 		let mockedUtil;
 		let config: TigrisClientConfig = {
 			serverUrl: testConfig.serverUrl,
@@ -870,38 +870,29 @@ describe("rpc tests", () => {
 			reset(mockedUtil);
 		});
 
-		it("uses 'default branch' when no branch name given", async () => {
+		it("succeeds when no branch name given", async () => {
 			expect(config["branch"]).toBeUndefined();
 			when(mockedUtil.branchNameFromEnv(anything())).thenReturn(undefined);
 			const tigris = new Tigris(config);
-			const dbPromise = tigris.getDatabase();
-			const db = await dbPromise;
-			expect(db.branch).toBe("");
-			return dbPromise;
-		});
+			const db = tigris.getDatabase();
 
-		it("accepts empty string for branch name", async () => {
-			when(mockedUtil.branchNameFromEnv(anything())).thenReturn({
-				name: "",
-				dynamicCreation: false,
-			});
-			const tigris = new Tigris({ ...config, branch: "" });
-			const dbPromise = tigris.getDatabase();
-			const db = await dbPromise;
-			expect(db.branch).toBe("");
-			return dbPromise;
+			expect(db.branch).toBe("main");
+			expect(db.usingDefaultBranch).toBeTruthy();
+
+			return db.initializeBranch();
 		});
 
 		it("skips creating branch for existing", async () => {
 			when(mockedUtil.branchNameFromEnv(anything())).thenReturn({
-				name: "staging",
+				name: Branch.Existing,
 				dynamicCreation: true,
 			});
 			const tigris = new Tigris(config);
-			const dbPromise = tigris.getDatabase();
-			const db = await dbPromise;
-			expect(db.branch).toBe("staging");
-			return dbPromise;
+			const db = tigris.getDatabase();
+
+			expect(db.branch).toBe(Branch.Existing);
+
+			return db.initializeBranch();
 		});
 
 		it("creates templated branch if not exist", async () => {
@@ -910,10 +901,10 @@ describe("rpc tests", () => {
 				dynamicCreation: true,
 			});
 			const tigris = new Tigris(config);
-			const dbPromise = tigris.getDatabase();
-			const db = await dbPromise;
+			const db = tigris.getDatabase();
+
 			expect(db.branch).toBe("fork_feature_1");
-			return dbPromise;
+			return db.initializeBranch();
 		});
 
 		it("throws error if non-templated branch does not exist", async () => {
@@ -922,8 +913,9 @@ describe("rpc tests", () => {
 				dynamicCreation: false,
 			});
 			const tigris = new Tigris(config);
-			const dbPromise = tigris.getDatabase();
-			return await expect(dbPromise).rejects.toThrow(DatabaseBranchError);
+			const db = tigris.getDatabase();
+
+			return await expect(db.initializeBranch()).rejects.toThrow(BranchNotFoundError);
 		});
 
 		it("fails to create branch if project does not exist", async () => {
@@ -932,27 +924,9 @@ describe("rpc tests", () => {
 				dynamicCreation: true,
 			});
 			const tigris = new Tigris(config);
-			const dbPromise = tigris.getDatabase();
-			try {
-				await dbPromise;
-			} catch (error) {
-				expect(error).toBeInstanceOf(Error);
-				expect((error as ServiceError).code).toEqual(Status.NOT_FOUND);
-			}
+			const db = tigris.getDatabase();
 
-			return await expect(dbPromise).rejects.toThrow(Error);
-		});
-
-		it("initializer succeeds if branch already exists", async () => {
-			when(mockedUtil.branchNameFromEnv(anything())).thenReturn({
-				name: Branch.Existing,
-				dynamicCreation: true,
-			});
-			const tigris = new Tigris(config);
-			const dbPromise = tigris.getDatabase();
-			const db = await dbPromise;
-			expect(db.branch).toBe(Branch.Existing);
-			return dbPromise;
+			return await expect(db.initializeBranch()).rejects.toThrow(BranchNotFoundError);
 		});
 	});
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -35,7 +35,7 @@ import { DecoratedSchemaProcessor } from "./schema/decorated-schema-processor";
 import { Log } from "./utils/logger";
 import { DecoratorMetaStorage } from "./decorators/metadata/decorator-meta-storage";
 import { getDecoratorMetaStorage } from "./globals";
-import { CollectionNotFoundError, DatabaseBranchError } from "./error";
+import { CollectionNotFoundError, BranchNotFoundError } from "./error";
 import { Status } from "@grpc/grpc-js/build/src/constants";
 
 const SetCookie = "Set-Cookie";
@@ -63,20 +63,19 @@ const BeginTransactionMethodName = "/tigrisdata.v1.Tigris/BeginTransaction";
  * ```
  */
 export type TemplatedBranchName = { name: string; dynamicCreation: boolean };
-const NoBranch: TemplatedBranchName = { name: "", dynamicCreation: false };
+const DefaultBranch: TemplatedBranchName = { name: "main", dynamicCreation: false };
 
 /**
  * Tigris Database class to manage database branches, collections and execute
  * transactions.
  */
 export class DB {
-	private readonly _db: string;
-	private _branch: string;
+	private readonly _name: string;
+	private readonly _branchVar: TemplatedBranchName;
 	private readonly grpcClient: TigrisClient;
 	private readonly config: TigrisClientConfig;
 	private readonly schemaProcessor: DecoratedSchemaProcessor;
 	private readonly _metadataStorage: DecoratorMetaStorage;
-	private readonly _ready: Promise<this>;
 
 	/**
 	 * Create an instance of Tigris Database class.
@@ -84,70 +83,16 @@ export class DB {
 	 * @example Recommended way to create instance using {@link TigrisClient.getDatabase}
 	 * ```
 	 * const client = new TigrisClient();
-	 * const db = await client.getDatabase();
-	 * ```
-	 *
-	 * @remarks
-	 * Highly recommend to use {@link TigrisClient.getDatabase} to create instance of this class and
-	 * not attempt to instantiate this class directly, it can have potential side effects
-	 * if database branch is not initialized properly.
-	 *
-	 * @privateRemarks
-	 * Object of this class depends on readiness state for proper initialization of database
-	 * and branch. To ensure object is ready to use:
-	 * ```
-	 * const instance = new DB(name, client, config);
-	 * const db: DB = await instance.ready;
-	 *
-	 * db.describe();
+	 * const db = client.getDatabase();
 	 * ```
 	 */
 	constructor(db: string, grpcClient: TigrisClient, config: TigrisClientConfig) {
-		this._db = db;
+		this._name = db;
 		this.grpcClient = grpcClient;
 		this.config = config;
 		this.schemaProcessor = DecoratedSchemaProcessor.Instance;
 		this._metadataStorage = getDecoratorMetaStorage();
-		this._branch = NoBranch.name;
-		this._ready = this.initializeDB();
-	}
-
-	/**
-	 * Initializes a database branch and returns DB object. A DB shouldn't be used
-	 * until it is initialized.
-	 *
-	 * Calls {@link describe} to assert that the branch in use already exists. If not, and the
-	 * branch name needs to be generated dynamically (ex - `preview_${GIT_BRANCH}`) then try to
-	 * create that branch.
-	 *
-	 * @throws Error if branch doesn't exist and/or cannot be created
-	 * @internal
-	 */
-	private async initializeDB(): Promise<this> {
-		const branchVar = Utility.branchNameFromEnv(this.config.branch) ?? NoBranch;
-		if (branchVar.name === NoBranch.name) {
-			return this;
-		}
-		const description = await this.describe();
-		const branchExists = description.branches.includes(branchVar.name);
-
-		if (!branchExists) {
-			if (branchVar.dynamicCreation) {
-				try {
-					await this.createBranch(branchVar.name);
-				} catch (error) {
-					if ((error as ServiceError).code !== Status.ALREADY_EXISTS) {
-						throw error;
-					}
-				}
-				Log.event(`Created database branch: ${branchVar.name}`);
-			} else {
-				throw new DatabaseBranchError(branchVar.name);
-			}
-		}
-		Log.info(`Using database branch: '${branchVar.name}'`);
-		this._branch = branchVar.name;
-		return this;
+		this._branchVar = Utility.branchNameFromEnv(config.branch) ?? DefaultBranch;
 	}
 
 	/**
@@ -220,7 +165,7 @@ export class DB {
 		return this.createOrUpdate(
 			collectionName,
 			schema,
-			() => new Collection(collectionName, this._db, this.branch, this.grpcClient, this.config)
+			() => new Collection(collectionName, this._name, this.branch, this.grpcClient, this.config)
 		);
 	}
 
@@ -232,13 +177,13 @@ export class DB {
 		return new Promise<R>((resolve, reject) => {
 			const rawJSONSchema: string = Utility._toJSONSchema(name, schema);
 			const createOrUpdateCollectionRequest = new ProtoCreateOrUpdateCollectionRequest()
-				.setProject(this._db)
+				.setProject(this._name)
 				.setBranch(this.branch)
 				.setCollection(name)
 				.setOnlyCreate(false)
 				.setSchema(Utility.stringToUint8Array(rawJSONSchema));
 
-			Log.event(`Creating collection: '${name}' in project: '${this._db}'`);
+			Log.event(`Creating collection: '${name}' in project: '${this._name}'`);
 			this.grpcClient.createOrUpdateCollection(
 				createOrUpdateCollectionRequest,
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -255,7 +200,9 @@ export class DB {
 
 	public listCollections(options?: CollectionOptions): Promise<Array<CollectionInfo>> {
 		return new Promise<Array<CollectionInfo>>((resolve, reject) => {
-			const request = new ProtoListCollectionsRequest().setProject(this.db).setBranch(this.branch);
+			const request = new ProtoListCollectionsRequest()
+				.setProject(this.name)
+				.setBranch(this.branch);
 			if (typeof options !== "undefined") {
 				return request.setOptions(new ProtoCollectionOptions());
 			}
@@ -295,7 +242,7 @@ export class DB {
 		return new Promise<DropCollectionResponse>((resolve, reject) => {
 			this.grpcClient.dropCollection(
 				new ProtoDropCollectionRequest()
-					.setProject(this.db)
+					.setProject(this.name)
 					.setBranch(this.branch)
 					.setCollection(collectionName),
 				(error, response) => {
@@ -325,7 +272,7 @@ export class DB {
 	public describe(): Promise<DatabaseDescription> {
 		return new Promise<DatabaseDescription>((resolve, reject) => {
 			this.grpcClient.describeDatabase(
-				new ProtoDescribeDatabaseRequest().setProject(this.db).setBranch(this.branch),
+				new ProtoDescribeDatabaseRequest().setProject(this.name).setBranch(this.branch),
 				(error, response) => {
 					if (error) {
 						reject(error);
@@ -371,7 +318,7 @@ export class DB {
 
 	public getCollection<T extends TigrisCollectionType>(nameOrClass: T | string): Collection<T> {
 		const collectionName = this.resolveNameFromCollectionClass(nameOrClass);
-		return new Collection<T>(collectionName, this.db, this.branch, this.grpcClient, this.config);
+		return new Collection<T>(collectionName, this.name, this.branch, this.grpcClient, this.config);
 	}
 
 	private resolveNameFromCollectionClass(nameOrClass: TigrisCollectionType | string) {
@@ -418,7 +365,7 @@ export class DB {
 	public beginTransaction(_options?: TransactionOptions): Promise<Session> {
 		return new Promise<Session>((resolve, reject) => {
 			const beginTxRequest = new ProtoBeginTransactionRequest()
-				.setProject(this._db)
+				.setProject(this._name)
 				.setBranch(this.branch);
 			const cookie: Metadata = new Metadata();
 			const call = this.grpcClient.makeUnaryRequest(
@@ -437,7 +384,7 @@ export class DB {
 								response.getTxCtx().getId(),
 								response.getTxCtx().getOrigin(),
 								this.grpcClient,
-								this.db,
+								this.name,
 								this.branch,
 								cookie
 							)
@@ -455,7 +402,7 @@ export class DB {
 
 	public createBranch(name: string): Promise<CreateBranchResponse> {
 		return new Promise((resolve, reject) => {
-			const req = new ProtoCreateBranchRequest().setProject(this.db).setBranch(name);
+			const req = new ProtoCreateBranchRequest().setProject(this.name).setBranch(name);
 			this.grpcClient.createBranch(req, (error, response) => {
 				if (error) {
 					reject(error);
@@ -468,7 +415,7 @@ export class DB {
 
 	public deleteBranch(name: string): Promise<DeleteBranchResponse> {
 		return new Promise((resolve, reject) => {
-			const req = new ProtoDeleteBranchRequest().setProject(this.db).setBranch(name);
+			const req = new ProtoDeleteBranchRequest().setProject(this.name).setBranch(name);
 			this.grpcClient.deleteBranch(req, (error, response) => {
 				if (error) {
 					reject(error);
@@ -479,15 +426,52 @@ export class DB {
 		});
 	}
 
-	get db(): string {
-		return this._db;
+	/**
+	 * Initializes a database branch if it needs to be dynamically created.
+	 *
+	 * Calls {@link describe|describe()} to assert that the branch in use already exists. If not, and the
+	 * branch name needs to be generated dynamically (ex - `preview_${GIT_BRANCH}`) then try to
+	 * create that branch.
+	 *
+	 * @example
+	 * ```
+	 * const client = new TigrisClient();
+	 * const db = client.getDatabase();
+	 * await db.initializeBranch();
+	 * ```
+	 *
+	 * @throws {@link Promise.reject} - Error if branch doesn't exist and/or cannot be created
+	 */
+	public async initializeBranch(): Promise<void> {
+		if (!this.usingDefaultBranch) {
+			try {
+				if (this._branchVar.dynamicCreation) {
+					await this.createBranch(this.branch);
+					Log.event(`Created database branch: ${this.branch}`);
+				} else {
+					const description: DatabaseDescription = await this.describe();
+					if (!description.branches.includes(this.branch)) {
+						throw new BranchNotFoundError(this.branch);
+					}
+				}
+			} catch (error) {
+				if ((error as ServiceError).code !== Status.ALREADY_EXISTS) {
+					throw new BranchNotFoundError(this.branch);
+				}
+			}
+			Log.info(`Using database branch: '${this.branch}'`);
+		}
+	}
+
+	get name(): string {
+		return this._name;
 	}
 
 	get branch(): string {
-		return this._branch;
+		return this._branchVar.name;
 	}
 
-	get ready(): Promise<this> {
-		return this._ready;
+	get usingDefaultBranch(): boolean {
+		return this.branch === DefaultBranch.name;
 	}
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -93,17 +93,12 @@ export class CollectionNotFoundError extends TigrisError {
 	}
 }
 
-export class DatabaseBranchError extends TigrisError {
-	constructor(name?: string) {
-		const errMsg = name
-			? `Database branch ${name} does not exist.`
-			: "Database branch name environment variable is required. " +
-			  "Run 'export TIGRIS_DB_BRANCH=YOUR_BRANCH_NAME' or include it in your environment file.";
-
-		super(errMsg);
+export class BranchNotFoundError extends TigrisError {
+	constructor(name: string) {
+		super(`Database branch ${name} does not exist`);
 	}
 
 	override get name(): string {
-		return "DatabaseBranchError";
+		return "BranchNotFoundError";
 	}
 }

--- a/src/tigris.ts
+++ b/src/tigris.ts
@@ -7,11 +7,11 @@ import { GetInfoRequest as ProtoGetInfoRequest } from "./proto/server/v1/observa
 import { HealthCheckInput as ProtoHealthCheckInput } from "./proto/server/v1/health_pb";
 
 import {
+	CacheMetadata,
 	DeleteCacheResponse,
 	ListCachesResponse,
 	ServerMetadata,
 	TigrisCollectionType,
-	CacheMetadata,
 } from "./types";
 
 import {
@@ -27,9 +27,11 @@ import { DecoratorMetaStorage } from "./decorators/metadata/decorator-meta-stora
 import { getDecoratorMetaStorage } from "./globals";
 import { Cache } from "./cache";
 import { CacheClient } from "./proto/server/v1/cache_grpc_pb";
-import { CreateCacheRequest as ProtoCreateCacheRequest } from "./proto/server/v1/cache_pb";
-import { DeleteCacheRequest as ProtoDeleteCacheRequest } from "./proto/server/v1/cache_pb";
-import { ListCachesRequest as ProtoListCachesRequest } from "./proto/server/v1/cache_pb";
+import {
+	CreateCacheRequest as ProtoCreateCacheRequest,
+	DeleteCacheRequest as ProtoDeleteCacheRequest,
+	ListCachesRequest as ProtoListCachesRequest,
+} from "./proto/server/v1/cache_pb";
 
 import { Status } from "@grpc/grpc-js/build/src/constants";
 import { initializeEnvironment } from "./utils/env-loader";
@@ -264,9 +266,8 @@ export class Tigris {
 		Log.info(`Using Tigris at: ${config.serverUrl}`);
 	}
 
-	public getDatabase(): Promise<DB> {
-		const db = new DB(this._config.projectName, this.grpcClient, this._config);
-		return db.ready;
+	public getDatabase(): DB {
+		return new DB(this._config.projectName, this.grpcClient, this._config);
 	}
 
 	/**
@@ -368,7 +369,7 @@ export class Tigris {
 	 * ```
 	 */
 	public async registerSchemas(collections: Array<TigrisCollectionType>) {
-		const tigrisDb = await this.getDatabase();
+		const tigrisDb = this.getDatabase();
 
 		for (const coll of collections) {
 			const found = this._metadataStorage.getCollectionByTarget(coll as Function);


### PR DESCRIPTION
## Describe your changes
- `getDatabase()` is sync again and made `initializeDB()` as a standalone method in `DB` as `initializeBranch()`
- Users will have to explicitly initialize branch, core functionality stays same

## How best to test these changes
- unit tests
