### PR TITLE
fix: removing branch name nerfing to handle it on server

### DIFF
--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -122,22 +122,6 @@ describe("utility tests", () => {
 			expect(generated.getCollation().getCase()).toBe("ci");
 		});
 
-		const nerfingTestCases = [
-			["main/fork", "main_fork"],
-			["main-fork", "main_fork"],
-			["main?fork", "main_fork"],
-			["sTaging21", "sTaging21"],
-			["hotfix/jira-23$4", "hotfix_jira_23_4"],
-			["", ""],
-			["release", "release"],
-			["zero ops", "zero_ops"],
-			["under_score", "under_score"],
-		];
-
-		test.each(nerfingTestCases)("nerfs the name - '%s'", (original, nerfed) => {
-			expect(Utility.nerfGitBranchName(original)).toBe(nerfed);
-		});
-
 		describe("get branch name from environment", () => {
 			const OLD_ENV = Object.assign({}, process.env);
 
@@ -154,7 +138,7 @@ describe("utility tests", () => {
 				["staging", undefined, undefined, "staging"],
 				["integration_${MY_VAR}_auto", undefined, undefined, undefined],
 				["integration_${MY_VAR}_auto", "NOT_SET", "feature_2", undefined],
-				["${MY_GIT_BRANCH}", "MY_GIT_BRANCH", "jira/1234", "jira_1234"],
+				["${MY_GIT_BRANCH}", "MY_GIT_BRANCH", "jira/1234", "jira/1234"],
 				["${MY_GIT_BRANCH", "MY_GIT_BRANCH", "jira/1234", "${MY_GIT_BRANCH"],
 				[undefined, undefined, undefined, undefined],
 			])("envVar - '%s'", (branchEnvValue, templateEnvKey, templateEnvValue, expected) => {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -54,10 +54,7 @@ export const Utility = {
 		const isTemplate = Utility.getTemplatedVar(maybeBranchName);
 		if (isTemplate) {
 			return isTemplate.extracted in process.env
-				? maybeBranchName.replace(
-						isTemplate.matched,
-						this.nerfGitBranchName(process.env[isTemplate.extracted])
-				  )
+				? maybeBranchName.replace(isTemplate.matched, process.env[isTemplate.extracted])
 				: undefined;
 		} else {
 			return maybeBranchName;
@@ -68,11 +65,6 @@ export const Utility = {
 	getTemplatedVar(input: string): { matched: string; extracted: string } {
 		const output = input.match(/\${(.*?)}/);
 		return output ? { matched: output[0], extracted: output[1] } : undefined;
-	},
-
-	/** @see tests for usage */
-	nerfGitBranchName(original: string) {
-		return original.replace(/[^\d\n.A-Za-z]/g, "_");
 	},
 
 	filterToString<T>(filter: Filter<T>): string {


### PR DESCRIPTION
## Describe your changes
- Will handle nerfing of branch names on server side as this may lead to same DB branch being used for multiple git branches
- Only impacts how we generate the branch names for preview deployments

## How best to test these changes
- Unit tests
