### PR TITLE
Explicit schema version support

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -142,6 +142,7 @@ export class DB {
 			);
 			collectionName = generatedColl.name;
 			schema = generatedColl.schema as TigrisSchema<T>;
+			schema["version"] = this.config.schemaVersion;
 		}
 		return this.createOrUpdate(
 			collectionName,

--- a/src/schema/decorated-schema-processor.ts
+++ b/src/schema/decorated-schema-processor.ts
@@ -4,6 +4,7 @@ import { TigrisCollectionType, TigrisDataTypes, TigrisSchema } from "../types";
 
 export type CollectionSchema<T extends TigrisCollectionType> = {
 	name: string;
+	version?: number;
 	schema: TigrisSchema<T>;
 };
 

--- a/src/tigris.ts
+++ b/src/tigris.ts
@@ -71,6 +71,13 @@ export interface TigrisClientConfig {
 	 * Database branch name
 	 */
 	branch?: string;
+
+	/**
+	 * Database schema version
+	 * Should be incremented when data models has changed.
+	 * If not set schema version 1 is implied.
+	 */
+	schemaVersion?: number;
 }
 
 class TokenSupplier {
@@ -137,6 +144,7 @@ const DEFAULT_URL = "api.preview.tigrisdata.cloud";
 const USER_AGENT_KEY = "user-agent";
 const USER_AGENT_VAL = "tigris-client-ts.grpc";
 const DEST_NAME_KEY = "destination-name";
+const SCHEMA_VERSION_KEY = "tigris-schema-version";
 
 /**
  * Tigris client
@@ -202,6 +210,10 @@ export class Tigris {
 		defaultMetadata.set(USER_AGENT_KEY, USER_AGENT_VAL);
 		defaultMetadata.set(DEST_NAME_KEY, config.serverUrl);
 
+		if (config.schemaVersion > 0) {
+			defaultMetadata.set(SCHEMA_VERSION_KEY, config.schemaVersion.toString());
+		}
+
 		if (
 			(config.serverUrl.includes("localhost") ||
 				config.serverUrl.startsWith("tigris-local-server:") ||
@@ -262,6 +274,7 @@ export class Tigris {
 				});
 			}
 		}
+
 		this._metadataStorage = getDecoratorMetaStorage();
 		Log.info(`Using Tigris at: ${config.serverUrl}`);
 	}


### PR DESCRIPTION
Support for explicit schema specified by the user.

* Adds schema version as a field of generated JSON schema
* Pass schema version in every API header

Can be set like:

```
--- a/lib/tigris.ts
+++ b/lib/tigris.ts
@@ -1,4 +1,5 @@
 import { DB, Tigris } from '@tigrisdata/core';
+import { TigrisSchemaVersion } from '../models/tigris/version';
 
 declare global {
   // eslint-disable-next-line no-var
@@ -10,7 +11,7 @@ declare global {
 // hot reloading. However, in production, Next.js would completely tear down before
 // restarting, thus, disconnecting and reconnecting to the Tigris.
 if (!global.tigris) {
-  const tigrisClient = new Tigris({serverUrl: "tigris-local-server:8081", projectName: "my_proj1", branch: "main"});
+  const tigrisClient = new Tigris({schemaVersion: TigrisSchemaVersion, serverUrl: "tigris-local-server:8081", projectName: "my_proj1", branch: "main"});
   global.tigris = tigrisClient.getDatabase();
 }
 const tigris = global.tigris;
diff --git a/models/tigris/version.ts b/models/tigris/version.ts
index e69de29..df8a8cd 100644
--- a/models/tigris/version.ts
+++ b/models/tigris/version.ts
@@ -0,0 +1 @@
+export const TigrisSchemaVersion = 5
\ No newline at end of file
diff --git a/scripts/setup.ts b/scripts/setup.ts
index a74a4d4..875d29f 100644
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -4,6 +4,7 @@ import { loadEnvConfig } from '@next/env';
 import { Order } from "../models/tigris/orders";
 import { Product } from "../models/tigris/products";
 import { User } from "../models/tigris/users";
+import { TigrisSchemaVersion } from "../models/tigris/version";
 
 // Run the config loader only when not executing within next runtime
 if (process.env.NODE_ENV === undefined) {
@@ -16,7 +17,7 @@ if (process.env.NODE_ENV === undefined) {
 
 async function main() {
   // setup client and register schemas
-  const tigrisClient = new Tigris({serverUrl: "localhost:8081", projectName: "my_proj1", branch: "main"});
+  const tigrisClient = new Tigris({schemaVersion: TigrisSchemaVersion, serverUrl: "localhost:8081", projectName: "my_proj1", branch: "main"});
   await tigrisClient.registerSchemas([
     Order,
     Product,
```