### PR TITLE
fix: Making search facets an object instead of ES6 map

### DIFF
--- a/src/__tests__/search/search.types.spec.ts
+++ b/src/__tests__/search/search.types.spec.ts
@@ -54,10 +54,10 @@ describe("SearchResponse parsing", () => {
 		input.getFacetsMap().set("author", searchFacet);
 		const parsed: SearchResult<unknown> = SearchResult.from(input, { serverUrl: "test" });
 
-		expect(parsed.facets.size).toBe(1);
-		expect(parsed.facets.get("author")).toBeDefined();
+		expect(Object.keys(parsed.facets).length).toBe(1);
+		expect(parsed.facets["author"]).toBeDefined();
 
-		const facetDistribution = parsed.facets.get("author");
+		const facetDistribution = parsed.facets["author"];
 		expect(facetDistribution.counts).toHaveLength(1);
 		expect(facetDistribution.counts[0].count).toBe(2);
 		expect(facetDistribution.counts[0].value).toBe("Marcel Proust");
@@ -71,7 +71,7 @@ describe("SearchResponse parsing", () => {
 		input.getFacetsMap().set("author", searchFacet);
 		const parsed: SearchResult<unknown> = SearchResult.from(input, { serverUrl: "test" });
 
-		const facetDistribution = parsed.facets.get("author");
+		const facetDistribution = parsed.facets["author"];
 		expect(facetDistribution.stats).toBeDefined();
 		expect(facetDistribution.stats.avg).toBe(4.5);
 		expect(facetDistribution.stats.min).toBe(0);
@@ -88,7 +88,7 @@ describe("SearchResponse parsing", () => {
 		expect(parsed.hits).toBeDefined();
 		expect(parsed.hits).toHaveLength(0);
 		expect(parsed.facets).toBeDefined();
-		expect(parsed.facets.size).toBe(0);
+		expect(Object.keys(parsed.facets).length).toBe(0);
 		expect(parsed.meta).toBeDefined();
 		expect(parsed.meta.found).toBe(0);
 		expect(parsed.meta.totalPages).toBe(1);

--- a/src/__tests__/test-search-service.ts
+++ b/src/__tests__/test-search-service.ts
@@ -143,7 +143,7 @@ class TestSearchService {
 				case SearchServiceFixtures.CreateIndex.Blog:
 					const schema = Buffer.from(call.request.getSchema_asB64(), "base64").toString();
 					expect(schema).toBe(
-						'{"title":"blogPosts","type":"object","properties":{"text":{"type":"string"},"comments":{"type":"array","items":{"type":"string"}},"author":{"type":"string"},"createdAt":{"type":"string","format":"date-time","sort":true}}}'
+						'{"title":"blogPosts","type":"object","properties":{"text":{"type":"string","facet":true},"comments":{"type":"array","items":{"type":"string"}},"author":{"type":"string"},"createdAt":{"type":"string","format":"date-time","sort":true}}}'
 					);
 					const resp = new CreateOrUpdateIndexResponse()
 						.setStatus("created")

--- a/src/__tests__/tigris.search.spec.ts
+++ b/src/__tests__/tigris.search.spec.ts
@@ -15,6 +15,7 @@ import { SearchService } from "../proto/server/v1/search_grpc_pb";
 import { Search } from "../search/search";
 import { IndexField } from "../decorators/tigris-index-field";
 import { TigrisIndex } from "../decorators/tigris-index";
+import * as repl from "repl";
 
 describe("Search Indexing", () => {
 	let tigris: Search;
@@ -162,8 +163,8 @@ describe("Search Indexing", () => {
 				});
 				expect(searchResult.meta.found).toBe(5);
 				expect(searchResult.meta.totalPages).toBe(5);
-				expect(searchResult.facets.get("title")).toBeDefined();
-				expect(searchResult.facets.get("title").counts).toEqual([
+				expect(searchResult.facets["title"]).toBeDefined();
+				expect(searchResult.facets["title"].counts).toEqual([
 					{
 						_count: 2,
 						_value: "Philosophy",
@@ -200,7 +201,7 @@ const bookSchema: TigrisIndexSchema<Book> = {
 
 @TigrisIndex(SearchServiceFixtures.CreateIndex.Blog)
 class BlogPost {
-	@IndexField()
+	@IndexField({ facet: true })
 	text: string;
 
 	@IndexField({ elements: TigrisDataTypes.STRING })


### PR DESCRIPTION
## Describe your changes
- facets in `SearchResult` being an ES6 map was not getting serialized to string
- changing them to object serializes it to string correctly

```diff
- private readonly _facets: ReadonlyMap<string, FacetCountDistribution>;
+ export type Facets = { [key: string]: FacetCountDistribution };
+ private readonly _facets: Facets;
```

```
console.log(JSON.stringify(result.facets));

{"author":{"_counts":[],"_stats":{"_avg":4.5,"_count":0,"_max":0,"_min":0,"_sum":0}}}

```

## How best to test these changes
- Existing unit tests

## Issue ticket number and link
closes #248 
