### PR TITLE
feat: GetDocs on search index to return metadata along with document

### DIFF
--- a/src/__tests__/test-search-service.ts
+++ b/src/__tests__/test-search-service.ts
@@ -45,8 +45,11 @@ export const SearchServiceFixtures = {
 	CreateIndex: {
 		Blog: "blogPosts",
 	},
-	SearchIndex: {
+	SearchDocs: {
 		UpdatedAtSeconds: Math.floor(Date.now() / 1000),
+	},
+	GetDocs: {
+		CreatedAtSeconds: 1672574400,
 	},
 };
 const enc = new TextEncoder();
@@ -99,14 +102,24 @@ class TestSearchService {
 			const resp = new GetDocumentResponse();
 			call.request.getIdsList().forEach((id) => {
 				const docAsString = JSON.stringify(SearchServiceFixtures.Docs.get(id));
-				resp.addDocuments(new IndexDoc().setDoc(enc.encode(docAsString)));
+				resp.addDocuments(
+					new IndexDoc()
+						.setDoc(enc.encode(docAsString))
+						.setMetadata(
+							new DocMeta().setCreatedAt(
+								new google_protobuf_timestamp_pb.Timestamp().setSeconds(
+									SearchServiceFixtures.GetDocs.CreatedAtSeconds
+								)
+							)
+						)
+				);
 			});
 			callback(undefined, resp);
 			return;
 		},
 		search(call: ServerWritableStream<SearchIndexRequest, SearchIndexResponse>): void {
 			const expectedUpdatedAt = new google_protobuf_timestamp_pb.Timestamp().setSeconds(
-				SearchServiceFixtures.SearchIndex.UpdatedAtSeconds
+				SearchServiceFixtures.SearchDocs.UpdatedAtSeconds
 			);
 			const resp = new SearchIndexResponse();
 			SearchServiceFixtures.Docs.forEach((d) =>

--- a/src/__tests__/test-search-service.ts
+++ b/src/__tests__/test-search-service.ts
@@ -45,6 +45,9 @@ export const SearchServiceFixtures = {
 	CreateIndex: {
 		Blog: "blogPosts",
 	},
+	SearchIndex: {
+		UpdatedAtSeconds: Math.floor(Date.now() / 1000),
+	},
 };
 const enc = new TextEncoder();
 
@@ -102,12 +105,15 @@ class TestSearchService {
 			return;
 		},
 		search(call: ServerWritableStream<SearchIndexRequest, SearchIndexResponse>): void {
+			const expectedUpdatedAt = new google_protobuf_timestamp_pb.Timestamp().setSeconds(
+				SearchServiceFixtures.SearchIndex.UpdatedAtSeconds
+			);
 			const resp = new SearchIndexResponse();
 			SearchServiceFixtures.Docs.forEach((d) =>
 				resp.addHits(
 					new IndexDoc()
 						.setDoc(enc.encode(JSON.stringify(d)))
-						.setMetadata(new DocMeta().setUpdatedAt(new google_protobuf_timestamp_pb.Timestamp()))
+						.setMetadata(new DocMeta().setUpdatedAt(expectedUpdatedAt))
 				)
 			);
 			resp.setMeta(

--- a/src/__tests__/tigris.search.spec.ts
+++ b/src/__tests__/tigris.search.spec.ts
@@ -135,16 +135,25 @@ describe("Search Indexing", () => {
 	describe("getDocuments", () => {
 		it("gets multiple documents", async () => {
 			const index = await tigris.getIndex<Book>(SearchServiceFixtures.Success);
-			const result = await index.getMany(Array.from(SearchServiceFixtures.Docs.keys()));
-			expect(result).toEqual(
-				expect.arrayContaining(Array.from(SearchServiceFixtures.Docs.values()))
-			);
+			const expectedDocs = Array.from(SearchServiceFixtures.Docs.values());
+			const recvdDocs = await index.getMany(Array.from(SearchServiceFixtures.Docs.keys()));
+			for (let i = 0; i < recvdDocs.length; i++) {
+				expect(recvdDocs[i].meta.updatedAt).toBeUndefined();
+				expect(recvdDocs[i].meta.createdAt).toStrictEqual(
+					new Date(SearchServiceFixtures.GetDocs.CreatedAtSeconds * 1000)
+				);
+				expect(recvdDocs[i].document).toEqual(expectedDocs[i]);
+			}
 		});
 
 		it("gets a single document", async () => {
 			const index = await tigris.getIndex<Book>(SearchServiceFixtures.Success);
 			const result = await index.getOne("1");
-			expect(result).toEqual(SearchServiceFixtures.Docs.get("1"));
+			expect(result.document).toEqual(SearchServiceFixtures.Docs.get("1"));
+			expect(result.meta.updatedAt).toBeUndefined();
+			expect(result.meta.createdAt).toStrictEqual(
+				new Date(SearchServiceFixtures.GetDocs.CreatedAtSeconds * 1000)
+			);
 		});
 	});
 
@@ -160,7 +169,7 @@ describe("Search Indexing", () => {
 					expect(expectedDocs).toContainEqual(h.document);
 					expect(h.meta.updatedAt).toBeDefined();
 					expect(h.meta.updatedAt).toStrictEqual(
-						new Date(SearchServiceFixtures.SearchIndex.UpdatedAtSeconds * 1000)
+						new Date(SearchServiceFixtures.SearchDocs.UpdatedAtSeconds * 1000)
 					);
 					expect(h.meta.createdAt).toBeUndefined();
 				});

--- a/src/__tests__/tigris.search.spec.ts
+++ b/src/__tests__/tigris.search.spec.ts
@@ -159,6 +159,9 @@ describe("Search Indexing", () => {
 				searchResult.hits.forEach((h: IndexedDoc<Book>) => {
 					expect(expectedDocs).toContainEqual(h.document);
 					expect(h.meta.updatedAt).toBeDefined();
+					expect(h.meta.updatedAt).toStrictEqual(
+						new Date(SearchServiceFixtures.SearchIndex.UpdatedAtSeconds * 1000)
+					);
 					expect(h.meta.createdAt).toBeUndefined();
 				});
 				expect(searchResult.meta.found).toBe(5);

--- a/src/__tests__/tigris.search.spec.ts
+++ b/src/__tests__/tigris.search.spec.ts
@@ -2,7 +2,7 @@ import { TigrisDataTypes } from "../types";
 import { Tigris } from "../tigris";
 import { Status } from "../constants";
 import {
-	Hit,
+	IndexedDoc,
 	MATCH_ALL_QUERY_STRING,
 	SearchIndex,
 	SearchIterator,
@@ -156,7 +156,7 @@ describe("Search Indexing", () => {
 			const expectedDocs = Array.from(SearchServiceFixtures.Docs.values());
 			// for await loop the iterator
 			for await (const searchResult of maybeIterator) {
-				searchResult.hits.forEach((h: Hit<Book>) => {
+				searchResult.hits.forEach((h: IndexedDoc<Book>) => {
 					expect(expectedDocs).toContainEqual(h.document);
 					expect(h.meta.updatedAt).toBeDefined();
 					expect(h.meta.createdAt).toBeUndefined();

--- a/src/search/result.ts
+++ b/src/search/result.ts
@@ -23,11 +23,11 @@ export type Facets = { [key: string]: FacetCountDistribution };
  * @typeParam T - type of Tigris collection
  */
 export class SearchResult<T> {
-	private readonly _hits: ReadonlyArray<Hit<T>>;
+	private readonly _hits: ReadonlyArray<IndexedDoc<T>>;
 	private readonly _facets: Facets;
 	private readonly _meta: SearchMeta | undefined;
 
-	constructor(hits: Array<Hit<T>>, facets: Facets, meta: SearchMeta | undefined) {
+	constructor(hits: Array<IndexedDoc<T>>, facets: Facets, meta: SearchMeta | undefined) {
 		this._hits = hits;
 		this._facets = facets;
 		this._meta = meta;
@@ -41,7 +41,7 @@ export class SearchResult<T> {
 	 * @returns matched documents as a list
 	 * @readonly
 	 */
-	get hits(): ReadonlyArray<Hit<T>> {
+	get hits(): ReadonlyArray<IndexedDoc<T>> {
 		return this._hits;
 	}
 
@@ -68,9 +68,9 @@ export class SearchResult<T> {
 	): SearchResult<T> {
 		const _meta =
 			typeof resp?.getMeta() !== "undefined" ? SearchMeta.from(resp.getMeta()) : SearchMeta.default;
-		const _hits: Array<Hit<T>> = resp
+		const _hits: Array<IndexedDoc<T>> = resp
 			.getHitsList()
-			.map((h: ProtoSearchHit | ProtoIndexDoc) => Hit.from<T>(h, config));
+			.map((h: ProtoSearchHit | ProtoIndexDoc) => IndexedDoc.from<T>(h, config));
 		const _facets: Facets = {};
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		for (const [k, _] of resp.getFacetsMap().toArray()) {
@@ -84,11 +84,11 @@ export class SearchResult<T> {
  * Matched document and relevance metadata for a search query
  * @typeParam T - type of Tigris collection
  */
-export class Hit<T extends TigrisCollectionType> {
+export class IndexedDoc<T extends TigrisCollectionType> {
 	private readonly _document: T;
-	private readonly _meta: HitMeta | undefined;
+	private readonly _meta: DocMeta | undefined;
 
-	constructor(document: T, meta: HitMeta | undefined) {
+	constructor(document: T, meta: DocMeta | undefined) {
 		this._document = document;
 		this._meta = meta;
 	}
@@ -105,22 +105,22 @@ export class Hit<T extends TigrisCollectionType> {
 	 * @returns relevance metadata for the matched document
 	 * @readonly
 	 */
-	get meta(): HitMeta | undefined {
+	get meta(): DocMeta | undefined {
 		return this._meta;
 	}
 
-	static from<T>(resp: ProtoSearchHit | ProtoIndexDoc, config: TigrisClientConfig): Hit<T> {
+	static from<T>(resp: ProtoSearchHit | ProtoIndexDoc, config: TigrisClientConfig): IndexedDoc<T> {
 		const docAsB64 = resp instanceof ProtoIndexDoc ? resp.getDoc_asB64() : resp.getData_asB64();
 		const document = Utility.jsonStringToObj<T>(Utility._base64Decode(docAsB64), config);
-		const meta = resp.hasMetadata() ? HitMeta.from(resp.getMetadata()) : undefined;
-		return new Hit<T>(document, meta);
+		const meta = resp.hasMetadata() ? DocMeta.from(resp.getMetadata()) : undefined;
+		return new IndexedDoc<T>(document, meta);
 	}
 }
 
 /**
  * Relevance metadata for a matched document
  */
-export class HitMeta {
+export class DocMeta {
 	private readonly _createdAt: Date | undefined;
 	private readonly _updatedAt: Date | undefined;
 
@@ -145,7 +145,7 @@ export class HitMeta {
 		return this._updatedAt;
 	}
 
-	static from(resp: ProtoSearchHitMeta): HitMeta {
+	static from(resp: ProtoSearchHitMeta): DocMeta {
 		const _createdAt =
 			typeof resp?.getCreatedAt()?.getSeconds() !== "undefined"
 				? new Date(resp.getCreatedAt().getSeconds() * 1000)
@@ -155,7 +155,7 @@ export class HitMeta {
 				? new Date(resp.getUpdatedAt().getSeconds() * 1000)
 				: undefined;
 
-		return new HitMeta(_createdAt, _updatedAt);
+		return new DocMeta(_createdAt, _updatedAt);
 	}
 }
 


### PR DESCRIPTION
## Describe your changes
- `getMany()` and `getOne()` APIs on search index to return metadata along with the document

```diff
- getMany(ids: Array<string>): Promise<Array<T>>;
+ getMany(ids: Array<string>): Promise<Array<IndexedDoc<T>>>;
```

where IndexedDoc is:
```ts
class IndexedDoc<T> {
	document: T;
	meta: DocMeta | undefined;
}
```

## How best to test these changes
- Unit tests for both `searchDocs` and `getDocs`
