### PR TITLE
fix: removing references for IndexedDoc proto message

### DIFF
--- a/src/__tests__/test-search-service.ts
+++ b/src/__tests__/test-search-service.ts
@@ -15,13 +15,11 @@ import {
 	DeleteDocumentResponse,
 	DeleteIndexRequest,
 	DeleteIndexResponse,
-	DocMeta,
 	DocStatus,
 	GetDocumentRequest,
 	GetDocumentResponse,
 	GetIndexRequest,
 	GetIndexResponse,
-	IndexDoc,
 	IndexInfo,
 	ListIndexesRequest,
 	ListIndexesResponse,
@@ -32,7 +30,14 @@ import {
 } from "../proto/server/v1/search_pb";
 import * as google_protobuf_timestamp_pb from "google-protobuf/google/protobuf/timestamp_pb";
 import { Utility } from "../utility";
-import { FacetCount, Page, SearchFacet, SearchMetadata } from "../proto/server/v1/api_pb";
+import {
+	FacetCount,
+	Page,
+	SearchFacet,
+	SearchMetadata,
+	SearchHit,
+	SearchHitMeta,
+} from "../proto/server/v1/api_pb";
 
 export const SearchServiceFixtures = {
 	Success: "validIndex",
@@ -103,10 +108,10 @@ class TestSearchService {
 			call.request.getIdsList().forEach((id) => {
 				const docAsString = JSON.stringify(SearchServiceFixtures.Docs.get(id));
 				resp.addDocuments(
-					new IndexDoc()
-						.setDoc(enc.encode(docAsString))
+					new SearchHit()
+						.setData(enc.encode(docAsString))
 						.setMetadata(
-							new DocMeta().setCreatedAt(
+							new SearchHitMeta().setCreatedAt(
 								new google_protobuf_timestamp_pb.Timestamp().setSeconds(
 									SearchServiceFixtures.GetDocs.CreatedAtSeconds
 								)
@@ -124,9 +129,9 @@ class TestSearchService {
 			const resp = new SearchIndexResponse();
 			SearchServiceFixtures.Docs.forEach((d) =>
 				resp.addHits(
-					new IndexDoc()
-						.setDoc(enc.encode(JSON.stringify(d)))
-						.setMetadata(new DocMeta().setUpdatedAt(expectedUpdatedAt))
+					new SearchHit()
+						.setData(enc.encode(JSON.stringify(d)))
+						.setMetadata(new SearchHitMeta().setUpdatedAt(expectedUpdatedAt))
 				)
 			);
 			resp.setMeta(

--- a/src/search/result.ts
+++ b/src/search/result.ts
@@ -8,10 +8,7 @@ import {
 	SearchMetadata as ProtoSearchMetadata,
 	SearchResponse as ProtoSearchResponse,
 } from "../proto/server/v1/api_pb";
-import {
-	IndexDoc as ProtoIndexDoc,
-	SearchIndexResponse as ProtoSearchIndexResponse,
-} from "../proto/server/v1/search_pb";
+import { SearchIndexResponse as ProtoSearchIndexResponse } from "../proto/server/v1/search_pb";
 import { TigrisClientConfig } from "../tigris";
 import { TigrisCollectionType } from "../types";
 import { Utility } from "../utility";
@@ -70,7 +67,7 @@ export class SearchResult<T> {
 			typeof resp?.getMeta() !== "undefined" ? SearchMeta.from(resp.getMeta()) : SearchMeta.default;
 		const _hits: Array<IndexedDoc<T>> = resp
 			.getHitsList()
-			.map((h: ProtoSearchHit | ProtoIndexDoc) => IndexedDoc.from<T>(h, config));
+			.map((h: ProtoSearchHit) => IndexedDoc.from<T>(h, config));
 		const _facets: Facets = {};
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		for (const [k, _] of resp.getFacetsMap().toArray()) {
@@ -109,8 +106,8 @@ export class IndexedDoc<T extends TigrisCollectionType> {
 		return this._meta;
 	}
 
-	static from<T>(resp: ProtoSearchHit | ProtoIndexDoc, config: TigrisClientConfig): IndexedDoc<T> {
-		const docAsB64 = resp instanceof ProtoIndexDoc ? resp.getDoc_asB64() : resp.getData_asB64();
+	static from<T>(resp: ProtoSearchHit, config: TigrisClientConfig): IndexedDoc<T> {
+		const docAsB64 = resp.getData_asB64();
 		const document = Utility.jsonStringToObj<T>(Utility._base64Decode(docAsB64), config);
 		const meta = resp.hasMetadata() ? DocMeta.from(resp.getMetadata()) : undefined;
 		return new IndexedDoc<T>(document, meta);


### PR DESCRIPTION
## Describe your changes
- Merging IndexDoc to `SearchHit` proto structure itself

## How best to test these changes
- Existing unit tests were already validating deserialization for both `SearchHit` and `IndexDoc`
