### PR TITLE
feat: Search annotations on a collection

### DIFF
--- a/src/__tests__/fixtures/json-schema/orders.json
+++ b/src/__tests__/fixtures/json-schema/orders.json
@@ -10,6 +10,7 @@
 		},
 		"customerId": {
 			"type": "string",
+			"index": false,
 			"sort": false,
 			"facet": false
 		},
@@ -26,7 +27,8 @@
 						"type": "object",
 						"properties": {
 							"name": {
-								"type": "string"
+								"type": "string",
+								"index": true
 							},
 							"tags": {
 								"type": "array",
@@ -41,6 +43,7 @@
 					},
 					"price": {
 						"type": "number",
+						"index": true,
 						"sort": true,
 						"facet": false
 					}

--- a/src/__tests__/fixtures/json-schema/orders.json
+++ b/src/__tests__/fixtures/json-schema/orders.json
@@ -9,7 +9,9 @@
 			"autoGenerate": true
 		},
 		"customerId": {
-			"type": "string"
+			"type": "string",
+			"sort": false,
+			"facet": false
 		},
 		"products": {
 			"type": "array",
@@ -38,7 +40,9 @@
 						"type": "integer"
 					},
 					"price": {
-						"type": "number"
+						"type": "number",
+						"sort": true,
+						"facet": false
 					}
 				}
 			}

--- a/src/__tests__/fixtures/json-schema/orders.json
+++ b/src/__tests__/fixtures/json-schema/orders.json
@@ -10,7 +10,7 @@
 		},
 		"customerId": {
 			"type": "string",
-			"index": false,
+			"searchIndex": false,
 			"sort": false,
 			"facet": false
 		},
@@ -28,7 +28,7 @@
 						"properties": {
 							"name": {
 								"type": "string",
-								"index": true
+								"searchIndex": true
 							},
 							"tags": {
 								"type": "array",
@@ -43,7 +43,7 @@
 					},
 					"price": {
 						"type": "number",
-						"index": true,
+						"searchIndex": true,
 						"sort": true,
 						"facet": false
 					}

--- a/src/__tests__/fixtures/json-schema/search/orders.json
+++ b/src/__tests__/fixtures/json-schema/search/orders.json
@@ -5,12 +5,12 @@
 		"orderId": {
 			"type": "string",
 			"format": "uuid",
-			"index": true,
+			"searchIndex": true,
 			"sort": true
 		},
 		"customerId": {
 			"type": "string",
-			"index": true,
+			"searchIndex": true,
 			"facet": false
 		},
 		"products": {
@@ -20,39 +20,39 @@
 				"properties": {
 					"name": {
 						"type": "string",
-						"index": true
+						"searchIndex": true
 					},
 					"brand": {
 						"type": "object",
 						"properties": {
 							"name": {
 								"type": "string",
-								"index": true
+								"searchIndex": true
 							},
 							"tags": {
 								"type": "array",
 								"items": {
 									"type": "string"
 								},
-								"index": false
+								"searchIndex": false
 							}
 						},
-						"index": true
+						"searchIndex": true
 					},
 					"upc": {
 						"type": "integer",
-						"index": false,
+						"searchIndex": false,
 						"sort": false
 					},
 					"price": {
 						"type": "number",
-						"index": true,
+						"searchIndex": true,
 						"sort": true,
 						"facet": false
 					}
 				}
 			},
-			"index": true
+			"searchIndex": true
 		}
 	}
 }

--- a/src/__tests__/fixtures/json-schema/search/orders.json
+++ b/src/__tests__/fixtures/json-schema/search/orders.json
@@ -5,10 +5,12 @@
 		"orderId": {
 			"type": "string",
 			"format": "uuid",
+			"index": true,
 			"sort": true
 		},
 		"customerId": {
 			"type": "string",
+			"index": true,
 			"facet": false
 		},
 		"products": {
@@ -17,13 +19,15 @@
 				"type": "object",
 				"properties": {
 					"name": {
-						"type": "string"
+						"type": "string",
+						"index": true
 					},
 					"brand": {
 						"type": "object",
 						"properties": {
 							"name": {
-								"type": "string"
+								"type": "string",
+								"index": true
 							},
 							"tags": {
 								"type": "array",
@@ -32,19 +36,23 @@
 								},
 								"index": false
 							}
-						}
+						},
+						"index": true
 					},
 					"upc": {
 						"type": "integer",
+						"index": false,
 						"sort": false
 					},
 					"price": {
 						"type": "number",
+						"index": true,
 						"sort": true,
 						"facet": false
 					}
 				}
-			}
+			},
+			"index": true
 		}
 	}
 }

--- a/src/__tests__/fixtures/schema/orders.ts
+++ b/src/__tests__/fixtures/schema/orders.ts
@@ -2,6 +2,7 @@ import { TigrisCollection } from "../../../decorators/tigris-collection";
 import { PrimaryKey } from "../../../decorators/tigris-primary-key";
 import { TigrisDataTypes, TigrisSchema } from "../../../types";
 import { Field } from "../../../decorators/tigris-field";
+import { SearchField } from "../../../decorators/tigris-search-field";
 
 /******************************************************************************
  * `Order` class demonstrates a Tigris collection schema generated using
@@ -10,12 +11,14 @@ import { Field } from "../../../decorators/tigris-field";
  * - has multiple primary keys
  * - has embedded objects
  * - has an Array of embedded objects
+ * - collection has search indexing enabled on certain fields
  * - and infers the type of collection fields automatically using Reflection APIs
  *****************************************************************************/
 export const ORDERS_COLLECTION_NAME = "orders";
 
 export class Brand {
 	@Field()
+	@SearchField()
 	name: string;
 
 	@Field({ elements: TigrisDataTypes.STRING })
@@ -33,6 +36,7 @@ export class Product {
 	upc: bigint;
 
 	@Field()
+	@SearchField({ sort: true, facet: false })
 	price: number;
 }
 
@@ -42,6 +46,7 @@ export class Order {
 	orderId: string;
 
 	@PrimaryKey({ order: 2 })
+	@SearchField({ sort: false, facet: false })
 	customerId: string;
 
 	@Field({ elements: Product })
@@ -66,6 +71,8 @@ export const OrderSchema: TigrisSchema<Order> = {
 	},
 	customerId: {
 		type: TigrisDataTypes.STRING,
+		sort: false,
+		facet: false,
 		primary_key: {
 			order: 2,
 			autoGenerate: false,
@@ -97,6 +104,8 @@ export const OrderSchema: TigrisSchema<Order> = {
 				},
 				price: {
 					type: TigrisDataTypes.NUMBER,
+					sort: true,
+					facet: false,
 				},
 			},
 		},

--- a/src/__tests__/fixtures/schema/orders.ts
+++ b/src/__tests__/fixtures/schema/orders.ts
@@ -46,7 +46,7 @@ export class Order {
 	orderId: string;
 
 	@PrimaryKey({ order: 2 })
-	@SearchField({ sort: false, facet: false })
+	@SearchField({ index: false, sort: false, facet: false })
 	customerId: string;
 
 	@Field({ elements: Product })
@@ -71,6 +71,7 @@ export const OrderSchema: TigrisSchema<Order> = {
 	},
 	customerId: {
 		type: TigrisDataTypes.STRING,
+		index: false,
 		sort: false,
 		facet: false,
 		primary_key: {
@@ -90,6 +91,7 @@ export const OrderSchema: TigrisSchema<Order> = {
 					type: {
 						name: {
 							type: TigrisDataTypes.STRING,
+							index: true,
 						},
 						tags: {
 							type: TigrisDataTypes.ARRAY,
@@ -104,6 +106,7 @@ export const OrderSchema: TigrisSchema<Order> = {
 				},
 				price: {
 					type: TigrisDataTypes.NUMBER,
+					index: true,
 					sort: true,
 					facet: false,
 				},

--- a/src/__tests__/fixtures/schema/orders.ts
+++ b/src/__tests__/fixtures/schema/orders.ts
@@ -46,7 +46,7 @@ export class Order {
 	orderId: string;
 
 	@PrimaryKey({ order: 2 })
-	@SearchField({ index: false, sort: false, facet: false })
+	@SearchField({ searchIndex: false, sort: false, facet: false })
 	customerId: string;
 
 	@Field({ elements: Product })
@@ -71,7 +71,7 @@ export const OrderSchema: TigrisSchema<Order> = {
 	},
 	customerId: {
 		type: TigrisDataTypes.STRING,
-		index: false,
+		searchIndex: false,
 		sort: false,
 		facet: false,
 		primary_key: {
@@ -91,7 +91,7 @@ export const OrderSchema: TigrisSchema<Order> = {
 					type: {
 						name: {
 							type: TigrisDataTypes.STRING,
-							index: true,
+							searchIndex: true,
 						},
 						tags: {
 							type: TigrisDataTypes.ARRAY,
@@ -106,7 +106,7 @@ export const OrderSchema: TigrisSchema<Order> = {
 				},
 				price: {
 					type: TigrisDataTypes.NUMBER,
-					index: true,
+					searchIndex: true,
 					sort: true,
 					facet: false,
 				},

--- a/src/__tests__/fixtures/schema/search/orders.ts
+++ b/src/__tests__/fixtures/schema/search/orders.ts
@@ -17,7 +17,7 @@ export class Brand {
 	@SearchField()
 	name: string;
 
-	@SearchField({ elements: TigrisDataTypes.STRING, index: false })
+	@SearchField({ elements: TigrisDataTypes.STRING, searchIndex: false })
 	tags: Set<string>;
 }
 
@@ -28,7 +28,7 @@ export class Product {
 	@SearchField()
 	brand: Brand;
 
-	@SearchField({ index: false, sort: false })
+	@SearchField({ searchIndex: false, sort: false })
 	upc: bigint;
 
 	@SearchField({ sort: true, facet: false })
@@ -56,33 +56,33 @@ export class Order {
 export const OrderSchema: TigrisIndexSchema<Order> = {
 	orderId: {
 		type: TigrisDataTypes.UUID,
-		index: true,
+		searchIndex: true,
 		sort: true,
 	},
 	customerId: {
 		type: TigrisDataTypes.STRING,
-		index: true,
+		searchIndex: true,
 		facet: false,
 	},
 	products: {
 		type: TigrisDataTypes.ARRAY,
-		index: true,
+		searchIndex: true,
 		items: {
 			type: {
 				name: {
 					type: TigrisDataTypes.STRING,
-					index: true,
+					searchIndex: true,
 				},
 				brand: {
-					index: true,
+					searchIndex: true,
 					type: {
 						name: {
 							type: TigrisDataTypes.STRING,
-							index: true,
+							searchIndex: true,
 						},
 						tags: {
 							type: TigrisDataTypes.ARRAY,
-							index: false,
+							searchIndex: false,
 							items: {
 								type: TigrisDataTypes.STRING,
 							},
@@ -91,12 +91,12 @@ export const OrderSchema: TigrisIndexSchema<Order> = {
 				},
 				upc: {
 					type: TigrisDataTypes.NUMBER_BIGINT,
-					index: false,
+					searchIndex: false,
 					sort: false,
 				},
 				price: {
 					type: TigrisDataTypes.NUMBER,
-					index: true,
+					searchIndex: true,
 					sort: true,
 					facet: false,
 				},

--- a/src/__tests__/fixtures/schema/search/orders.ts
+++ b/src/__tests__/fixtures/schema/search/orders.ts
@@ -28,7 +28,7 @@ export class Product {
 	@SearchField()
 	brand: Brand;
 
-	@SearchField({ sort: false })
+	@SearchField({ index: false, sort: false })
 	upc: bigint;
 
 	@SearchField({ sort: true, facet: false })
@@ -56,23 +56,29 @@ export class Order {
 export const OrderSchema: TigrisIndexSchema<Order> = {
 	orderId: {
 		type: TigrisDataTypes.UUID,
+		index: true,
 		sort: true,
 	},
 	customerId: {
 		type: TigrisDataTypes.STRING,
+		index: true,
 		facet: false,
 	},
 	products: {
 		type: TigrisDataTypes.ARRAY,
+		index: true,
 		items: {
 			type: {
 				name: {
 					type: TigrisDataTypes.STRING,
+					index: true,
 				},
 				brand: {
+					index: true,
 					type: {
 						name: {
 							type: TigrisDataTypes.STRING,
+							index: true,
 						},
 						tags: {
 							type: TigrisDataTypes.ARRAY,
@@ -85,10 +91,12 @@ export const OrderSchema: TigrisIndexSchema<Order> = {
 				},
 				upc: {
 					type: TigrisDataTypes.NUMBER_BIGINT,
+					index: false,
 					sort: false,
 				},
 				price: {
 					type: TigrisDataTypes.NUMBER,
+					index: true,
 					sort: true,
 					facet: false,
 				},

--- a/src/__tests__/test-search-service.ts
+++ b/src/__tests__/test-search-service.ts
@@ -167,7 +167,7 @@ class TestSearchService {
 				case SearchServiceFixtures.CreateIndex.Blog:
 					const schema = Buffer.from(call.request.getSchema_asB64(), "base64").toString();
 					expect(schema).toBe(
-						'{"title":"blogPosts","type":"object","properties":{"text":{"type":"string","facet":true},"comments":{"type":"array","items":{"type":"string"}},"author":{"type":"string"},"createdAt":{"type":"string","format":"date-time","sort":true}}}'
+						'{"title":"blogPosts","type":"object","properties":{"text":{"type":"string","index":true,"facet":true},"comments":{"type":"array","items":{"type":"string"},"index":true},"author":{"type":"string","index":true},"createdAt":{"type":"string","format":"date-time","index":true,"sort":true}}}'
 					);
 					const resp = new CreateOrUpdateIndexResponse()
 						.setStatus("created")

--- a/src/__tests__/test-search-service.ts
+++ b/src/__tests__/test-search-service.ts
@@ -167,7 +167,7 @@ class TestSearchService {
 				case SearchServiceFixtures.CreateIndex.Blog:
 					const schema = Buffer.from(call.request.getSchema_asB64(), "base64").toString();
 					expect(schema).toBe(
-						'{"title":"blogPosts","type":"object","properties":{"text":{"type":"string","index":true,"facet":true},"comments":{"type":"array","items":{"type":"string"},"index":true},"author":{"type":"string","index":true},"createdAt":{"type":"string","format":"date-time","index":true,"sort":true}}}'
+						'{"title":"blogPosts","type":"object","properties":{"text":{"type":"string","searchIndex":true,"facet":true},"comments":{"type":"array","items":{"type":"string"},"searchIndex":true},"author":{"type":"string","searchIndex":true},"createdAt":{"type":"string","format":"date-time","searchIndex":true,"sort":true}}}'
 					);
 					const resp = new CreateOrUpdateIndexResponse()
 						.setStatus("created")

--- a/src/decorators/metadata/decorator-meta-storage.ts
+++ b/src/decorators/metadata/decorator-meta-storage.ts
@@ -34,13 +34,13 @@ export class DecoratorMetaStorage {
 		}
 	}
 
-	getFieldsByTarget(target: Function): Array<FieldMetadata> {
+	getCollectionFieldsByTarget(target: Function): Array<FieldMetadata> {
 		return this.collectionFields.filter(function (field) {
 			return field.target === target;
 		});
 	}
 
-	getIndexFieldsByTarget(target: Function): Array<SearchFieldMetadata> {
+	getSearchFieldsByTarget(target: Function): Array<SearchFieldMetadata> {
 		return this.searchFields.filter(function (field) {
 			return field.target === target;
 		});

--- a/src/decorators/metadata/field-metadata.ts
+++ b/src/decorators/metadata/field-metadata.ts
@@ -1,4 +1,4 @@
-import { TigrisDataTypes, TigrisFieldOptions } from "../../types";
+import { TigrisDataTypes, CollectionFieldOptions } from "../../types";
 
 /**@internal*/
 export interface FieldMetadata {
@@ -7,5 +7,5 @@ export interface FieldMetadata {
 	readonly type: TigrisDataTypes;
 	readonly embedType?: TigrisDataTypes | Function;
 	readonly arrayDepth?: number;
-	readonly schemaFieldOptions?: TigrisFieldOptions;
+	readonly schemaFieldOptions?: CollectionFieldOptions;
 }

--- a/src/decorators/tigris-field.ts
+++ b/src/decorators/tigris-field.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { TigrisDataTypes, TigrisFieldOptions } from "../types";
+import { TigrisDataTypes, CollectionFieldOptions } from "../types";
 import { EmbeddedFieldOptions } from "./options/embedded-field-options";
 import {
 	CannotInferFieldTypeError,
@@ -34,7 +34,7 @@ export function Field(type: TigrisDataTypes): PropertyDecorator;
  * @param options - `EmbeddedFieldOptions` are only applicable to Array and Object types
  * 									of schema field.
  */
-export function Field(options: EmbeddedFieldOptions & TigrisFieldOptions): PropertyDecorator;
+export function Field(options: EmbeddedFieldOptions & CollectionFieldOptions): PropertyDecorator;
 /**
  * Field decorator is used to mark a class property as Collection field. Only properties
  * decorated with `@Field` will be used in Schema.
@@ -47,7 +47,7 @@ export function Field(options: EmbeddedFieldOptions & TigrisFieldOptions): Prope
  */
 export function Field(
 	type: TigrisDataTypes,
-	options?: EmbeddedFieldOptions & TigrisFieldOptions
+	options?: EmbeddedFieldOptions & CollectionFieldOptions
 ): PropertyDecorator;
 
 /**
@@ -55,13 +55,13 @@ export function Field(
  * decorated with `@Field` will be used in Schema.
  */
 export function Field(
-	typeOrOptions?: TigrisDataTypes | (TigrisFieldOptions & EmbeddedFieldOptions),
-	options?: TigrisFieldOptions & EmbeddedFieldOptions
+	typeOrOptions?: TigrisDataTypes | (CollectionFieldOptions & EmbeddedFieldOptions),
+	options?: CollectionFieldOptions & EmbeddedFieldOptions
 ): PropertyDecorator {
 	return function (target, propertyName) {
 		propertyName = propertyName.toString();
 		let propertyType: TigrisDataTypes | undefined;
-		let fieldOptions: TigrisFieldOptions;
+		let fieldOptions: CollectionFieldOptions;
 		let embedOptions: EmbeddedFieldOptions;
 
 		if (typeof typeOrOptions === "string") {
@@ -70,14 +70,14 @@ export function Field(
 			if (isEmbeddedOption(typeOrOptions)) {
 				embedOptions = typeOrOptions as EmbeddedFieldOptions;
 			}
-			fieldOptions = typeOrOptions as TigrisFieldOptions;
+			fieldOptions = typeOrOptions as CollectionFieldOptions;
 		}
 
 		if (typeof options === "object") {
 			if (isEmbeddedOption(options)) {
 				embedOptions = options as EmbeddedFieldOptions;
 			}
-			fieldOptions = options as TigrisFieldOptions;
+			fieldOptions = options as CollectionFieldOptions;
 		}
 
 		// if type or options are not specified, infer using reflection

--- a/src/decorators/tigris-search-field.ts
+++ b/src/decorators/tigris-search-field.ts
@@ -80,6 +80,9 @@ export function SearchField(
 		if (propertyType === TigrisDataTypes.ARRAY && embedOptions?.elements === undefined) {
 			throw new IncompleteArrayTypeDefError(target, propertyName);
 		}
+		const defaultFieldOption = { index: true };
+		fieldOptions = { ...defaultFieldOption, ...fieldOptions };
+
 		getDecoratorMetaStorage().searchFields.push({
 			name: propertyName,
 			type: propertyType,

--- a/src/decorators/tigris-search-field.ts
+++ b/src/decorators/tigris-search-field.ts
@@ -80,7 +80,7 @@ export function SearchField(
 		if (propertyType === TigrisDataTypes.ARRAY && embedOptions?.elements === undefined) {
 			throw new IncompleteArrayTypeDefError(target, propertyName);
 		}
-		const defaultFieldOption = { index: true };
+		const defaultFieldOption: SearchFieldOptions = { searchIndex: true };
 		fieldOptions = { ...defaultFieldOption, ...fieldOptions };
 
 		getDecoratorMetaStorage().searchFields.push({

--- a/src/decorators/utils.ts
+++ b/src/decorators/utils.ts
@@ -1,4 +1,4 @@
-import { TigrisDataTypes, TigrisFieldOptions } from "../types";
+import { TigrisDataTypes, CollectionFieldOptions } from "../types";
 import { EmbeddedFieldOptions } from "./options/embedded-field-options";
 
 export function getTigrisTypeFromReflectedType(reflectedType: string): TigrisDataTypes | undefined {
@@ -24,7 +24,7 @@ export function getTigrisTypeFromReflectedType(reflectedType: string): TigrisDat
 }
 
 export function isEmbeddedOption(
-	options: TigrisFieldOptions | EmbeddedFieldOptions
+	options: CollectionFieldOptions | EmbeddedFieldOptions
 ): options is EmbeddedFieldOptions {
 	return (options as EmbeddedFieldOptions).elements !== undefined;
 }

--- a/src/schema/decorated-schema-processor.ts
+++ b/src/schema/decorated-schema-processor.ts
@@ -65,40 +65,37 @@ export class DecoratedSchemaProcessor {
 			const key = field.name;
 			if (!(key in schema)) {
 				schema[key] = { type: field.type };
+			}
 
-				let arrayItems: Object, arrayDepth: number;
+			let arrayItems: Object, arrayDepth: number;
 
-				switch (field.type) {
-					case TigrisDataTypes.ARRAY:
-						arrayItems =
-							typeof field.embedType === "function"
-								? {
-										type: this.buildTigrisSchema(field.embedType as Function, forCollection),
-								  }
-								: { type: field.embedType as TigrisDataTypes };
-						arrayDepth = field.arrayDepth && field.arrayDepth > 1 ? field.arrayDepth : 1;
-						schema[key] = this.buildNestedArray(arrayItems, arrayDepth);
-						break;
-					case TigrisDataTypes.OBJECT:
-						if (typeof field.embedType === "function") {
-							const embedSchema = this.buildTigrisSchema(
-								field.embedType as Function,
-								forCollection
-							);
-							// generate embedded schema as its a class
-							if (Object.keys(embedSchema).length > 0) {
-								schema[key] = {
+			switch (field.type) {
+				case TigrisDataTypes.ARRAY:
+					arrayItems =
+						typeof field.embedType === "function"
+							? {
 									type: this.buildTigrisSchema(field.embedType as Function, forCollection),
-								};
-							}
+							  }
+							: { type: field.embedType as TigrisDataTypes };
+					arrayDepth = field.arrayDepth && field.arrayDepth > 1 ? field.arrayDepth : 1;
+					schema[key] = this.buildNestedArray(arrayItems, arrayDepth);
+					break;
+				case TigrisDataTypes.OBJECT:
+					if (typeof field.embedType === "function") {
+						const embedSchema = this.buildTigrisSchema(field.embedType as Function, forCollection);
+						// generate embedded schema as its a class
+						if (Object.keys(embedSchema).length > 0) {
+							schema[key] = {
+								type: this.buildTigrisSchema(field.embedType as Function, forCollection),
+							};
 						}
-						break;
-					case TigrisDataTypes.STRING:
-						if (field.schemaFieldOptions && "maxLength" in field.schemaFieldOptions) {
-							schema[key].maxLength = field.schemaFieldOptions.maxLength;
-						}
-						break;
-				}
+					}
+					break;
+				case TigrisDataTypes.STRING:
+					if (field.schemaFieldOptions && "maxLength" in field.schemaFieldOptions) {
+						schema[key].maxLength = field.schemaFieldOptions.maxLength;
+					}
+					break;
 			}
 
 			// process any field optionals

--- a/src/schema/decorated-schema-processor.ts
+++ b/src/schema/decorated-schema-processor.ts
@@ -101,7 +101,7 @@ export class DecoratedSchemaProcessor {
 			// process any field optionals
 			if (field.schemaFieldOptions) {
 				// set value for field,  if any
-				for (const opKey of ["default", "timestamp", "index", "sort", "facet"])
+				for (const opKey of ["default", "timestamp", "searchIndex", "sort", "facet"])
 					if (opKey in field.schemaFieldOptions) {
 						schema[key][opKey] = field.schemaFieldOptions[opKey];
 					}

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -10,7 +10,7 @@ import { Status } from "../constants";
 import { TigrisError } from "../error";
 
 export type SearchFieldOptions = {
-	index?: boolean;
+	searchIndex?: boolean;
 	sort?: boolean;
 	facet?: boolean;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import {
 } from "./proto/server/v1/api_pb";
 import { Status } from "./constants";
 import { Collation } from "./search/query";
+import { SearchFieldOptions } from "./search";
 
 export class DatabaseInfo {
 	private readonly _name: string;
@@ -623,7 +624,7 @@ export enum Generated {
 
 export type AutoTimestamp = "createdAt" | "updatedAt";
 
-export type TigrisFieldOptions = {
+export type CollectionFieldOptions = {
 	/**
 	 * Max length for "string" type of fields
 	 */
@@ -644,7 +645,8 @@ export type TigrisSchema<T extends TigrisCollectionType> = {
 		type: TigrisDataTypes | TigrisSchema<unknown>;
 		primary_key?: PrimaryKeyOptions;
 		items?: TigrisArrayItem;
-	} & TigrisFieldOptions;
+	} & CollectionFieldOptions &
+		SearchFieldOptions;
 };
 
 export type TigrisArrayItem = {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -387,8 +387,8 @@ export const Utility = {
 			}
 
 			// indexing optionals
-			if ("index" in schema[property]) {
-				thisProperty["index"] = schema[property]["index"];
+			if ("searchIndex" in schema[property]) {
+				thisProperty["searchIndex"] = schema[property]["searchIndex"];
 			}
 			if ("sort" in schema[property]) {
 				thisProperty["sort"] = schema[property]["sort"];


### PR DESCRIPTION
## Describe your changes
- Enables annotating collection fields as search index fields

## How best to test these changes
- [orders.ts](https://github.com/tigrisdata/tigris-client-ts/pull/265/files#diff-db704cf226bd5733e2d449c7f142614faba3079cd97ade6a82cf91f7f2ea19a7) represents a collection data model with search fields and [orders.json](https://github.com/tigrisdata/tigris-client-ts/pull/265/files#diff-7b1ce5c287129caf64eab185fea580874a81525a156c7d40f8c849966d9e1fa5) is the generated json schema sent to the server
- Unit tests

## Issue ticket number and link
closes #259 