### PR TITLE
feat: static type checking for query constructs

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -40,7 +40,6 @@ const EXPECTED_EXPORTS = [
 	"ListCachesResponse",
 	"LogicalOperator",
 	"MATCH_ALL_QUERY_STRING",
-	"Order",
 	"Page",
 	"PrimaryKey",
 	"RollbackTransactionResponse",

--- a/src/__tests__/tigris.readfields.spec.ts
+++ b/src/__tests__/tigris.readfields.spec.ts
@@ -1,24 +1,58 @@
 import { ReadFields } from "../types";
 import { Utility } from "../utility";
+import { Field } from "../decorators/tigris-field";
+import { TigrisCollection } from "../decorators/tigris-collection";
+import { PrimaryKey } from "../decorators/tigris-primary-key";
 
 describe("readFields tests", () => {
-	it("readFields1", () => {
-		const readFields: ReadFields = {
-			include: ["id", "title"],
-		};
-		expect(Utility.readFieldString(readFields)).toBe('{"id":true,"title":true}');
+	it("serializes empty object", () => {
+		expect(Utility.readFieldString({})).toBe("{}");
 	});
-	it("readFields2", () => {
-		const readFields: ReadFields = {
-			exclude: ["id", "title"],
+
+	it("serializes include only", () => {
+		const readFields: ReadFields<Student> = {
+			include: ["id", "name", "address.street"],
 		};
-		expect(Utility.readFieldString(readFields)).toBe('{"id":false,"title":false}');
+		expect(Utility.readFieldString(readFields)).toBe(
+			'{"id":true,"name":true,"address.street":true}'
+		);
 	});
-	it("readFields3", () => {
-		const readFields: ReadFields = {
-			include: ["id", "title"],
-			exclude: ["author"],
+
+	it("serializes exclude only", () => {
+		const readFields: ReadFields<Student> = {
+			exclude: ["id", "address.city"],
 		};
-		expect(Utility.readFieldString(readFields)).toBe('{"id":true,"title":true,"author":false}');
+		expect(Utility.readFieldString(readFields)).toBe('{"id":false,"address.city":false}');
+	});
+
+	it("serializes includes and excludes", () => {
+		const readFields: ReadFields<Student> = {
+			include: ["id", "address"],
+			exclude: ["name"],
+		};
+		expect(Utility.readFieldString(readFields)).toBe('{"id":true,"address":true,"name":false}');
 	});
 });
+
+class Address {
+	@Field()
+	street: string;
+
+	@Field()
+	city: string;
+}
+
+@TigrisCollection("students")
+class Student {
+	@PrimaryKey({ order: 1 })
+	id: string;
+
+	@Field()
+	name: string;
+
+	@Field()
+	balance: number;
+
+	@Field()
+	address: Address;
+}

--- a/src/__tests__/tigris.search.spec.ts
+++ b/src/__tests__/tigris.search.spec.ts
@@ -1,19 +1,18 @@
-import { LogicalOperator, Order, SelectorFilterOperator, TigrisDataTypes } from "../types";
+import { TigrisDataTypes } from "../types";
 import { Tigris } from "../tigris";
 import { Status } from "../constants";
 import {
 	IndexedDoc,
 	MATCH_ALL_QUERY_STRING,
+	Search,
 	SearchIndex,
 	SearchIterator,
-	SearchQuery,
 	TigrisIndexSchema,
 	TigrisIndexType,
 } from "../search";
 import { Server, ServerCredentials } from "@grpc/grpc-js";
 import TestSearchService, { SearchServiceFixtures } from "./test-search-service";
 import { SearchService } from "../proto/server/v1/search_grpc_pb";
-import { Search } from "../search";
 import { SearchField } from "../decorators/tigris-search-field";
 import { TigrisSearchIndex } from "../decorators/tigris-search-index";
 

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -9,6 +9,10 @@ import {
 	MATCH_ALL_QUERY_STRING,
 	SearchQueryOptions,
 } from "../search";
+import { TigrisCollection } from "../decorators/tigris-collection";
+import { PrimaryKey } from "../decorators/tigris-primary-key";
+import * as stream from "stream";
+import { Field } from "../decorators/tigris-field";
 
 describe("utility tests", () => {
 	it("base64encode", () => {
@@ -36,32 +40,32 @@ describe("utility tests", () => {
 	});
 
 	it("serializes FacetFields to string", () => {
-		const fields: FacetFields = ["field_1", "field_2"];
+		const fields: FacetFields<Student> = ["balance", "address.city"];
 		const serialized: string = Utility.facetQueryToString(fields);
 		expect(serialized).toBe(
-			'{"field_1":{"size":10,"type":"value"},"field_2":{"size":10,"type":"value"}}'
+			'{"balance":{"size":10,"type":"value"},"address.city":{"size":10,"type":"value"}}'
 		);
 	});
 
 	it("serializes FacetFieldOptions to string", () => {
-		const fields: FacetFieldOptions = {
-			field_1: Utility.createFacetQueryOptions(),
-			field_2: { size: 10, type: FacetQueryFieldType.VALUE },
+		const fields: FacetFieldOptions<Student> = {
+			name: Utility.createFacetQueryOptions(),
+			"address.street": { size: 10, type: FacetQueryFieldType.VALUE },
 		};
 		const serialized: string = Utility.facetQueryToString(fields);
 		expect(serialized).toBe(
-			'{"field_1":{"size":10,"type":"value"},"field_2":{"size":10,"type":"value"}}'
+			'{"name":{"size":10,"type":"value"},"address.street":{"size":10,"type":"value"}}'
 		);
 	});
 
 	it("equivalent serialization of FacetFieldsQuery", () => {
-		const facetFields: FacetFieldsQuery = ["field_1", "field_2"];
-		const fieldOptions: FacetFieldsQuery = {
-			field_1: Utility.createFacetQueryOptions(),
-			field_2: { size: 10, type: FacetQueryFieldType.VALUE },
+		const facetFields: FacetFieldsQuery<Student> = ["name", "address.street"];
+		const facetWithOptions: FacetFieldsQuery<Student> = {
+			name: Utility.createFacetQueryOptions(),
+			"address.street": { size: 10, type: FacetQueryFieldType.VALUE },
 		};
 		const serializedFields = Utility.facetQueryToString(facetFields);
-		expect(serializedFields).toBe(Utility.facetQueryToString(fieldOptions));
+		expect(serializedFields).toBe(Utility.facetQueryToString(facetWithOptions));
 	});
 
 	it.each([
@@ -199,3 +203,26 @@ describe("utility tests", () => {
 		});
 	});
 });
+
+class Address {
+	@Field()
+	street: string;
+
+	@Field()
+	city: string;
+}
+
+@TigrisCollection("students")
+class Student {
+	@PrimaryKey({ order: 1 })
+	id: string;
+
+	@Field()
+	name: string;
+
+	@Field()
+	balance: number;
+
+	@Field()
+	address: Address;
+}

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -1,5 +1,5 @@
 import { Utility } from "../utility";
-import { Order } from "../types";
+import { LogicalOperator, Order, SelectorFilterOperator } from "../types";
 import {
 	Case,
 	FacetFieldOptions,
@@ -7,8 +7,10 @@ import {
 	FacetFieldsQuery,
 	FacetQueryFieldType,
 	MATCH_ALL_QUERY_STRING,
+	SearchQuery,
 	SearchQueryOptions,
 } from "../search";
+import { SearchRequest as ProtoSearchRequest } from "../proto/server/v1/api_pb";
 import { TigrisCollection } from "../decorators/tigris-collection";
 import { PrimaryKey } from "../decorators/tigris-primary-key";
 import * as stream from "stream";
@@ -85,38 +87,87 @@ describe("utility tests", () => {
 	});
 
 	describe("createProtoSearchRequest", () => {
-		const dbName = "my_test_db";
-		const branch = "my_test_branch";
-		const collectionName = "my_test_collection";
-
-		it("sets query string to match all if not provided", () => {
-			const emptyRequest = {};
-			const generated = Utility.createProtoSearchRequest(
-				dbName,
-				branch,
-				collectionName,
-				emptyRequest
-			);
-			expect(generated.getQ()).toBe("");
+		let request: ProtoSearchRequest;
+		beforeEach(() => {
+			request = new ProtoSearchRequest();
 		});
 
-		it("populates projectName and collection name", () => {
-			const emptyRequest = { q: "" };
-			const generated = Utility.createProtoSearchRequest(
-				dbName,
-				branch,
-				collectionName,
-				emptyRequest
-			);
-			expect(generated.getProject()).toBe(dbName);
-			expect(generated.getBranch()).toBe(branch);
-			expect(generated.getCollection()).toBe(collectionName);
+		it("creates default match all search request", () => {
+			const query = {};
+			Utility.protoSearchRequestFromQuery(query, request);
+			expect(request.getQ()).toBe(MATCH_ALL_QUERY_STRING);
+			expect(request.getSearchFieldsList()).toEqual([]);
+			expect(request.getFilter()).toBe("");
+			expect(request.getFacet()).toBe("");
+			expect(request.getSort()).toBe("");
+			expect(request.getIncludeFieldsList()).toEqual([]);
+			expect(request.getExcludeFieldsList()).toEqual([]);
+			expect(request.getPage()).toBe(0);
+			expect(request.getPageSize()).toBe(0);
+			expect(request.getCollation()).toBeUndefined();
 		});
 
-		it("creates default match all query string", () => {
-			const request = { q: undefined };
-			const generated = Utility.createProtoSearchRequest(dbName, branch, collectionName, request);
-			expect(generated.getQ()).toBe(MATCH_ALL_QUERY_STRING);
+		it("sets searchFields", () => {
+			const query: SearchQuery<Student> = { searchFields: ["name", "address.street"] };
+			Utility.protoSearchRequestFromQuery(query, request);
+
+			expect(request.getSearchFieldsList()).toEqual(["name", "address.street"]);
+		});
+
+		it("sets filter", () => {
+			const query: SearchQuery<Student> = {
+				filter: { op: SelectorFilterOperator.GT, fields: { balance: 25 } },
+			};
+			Utility.protoSearchRequestFromQuery(query, request);
+
+			expect(request.getFilter()).toEqual(Utility.stringToUint8Array('{"balance":{"$gt":25}}'));
+		});
+
+		it("sets facets", () => {
+			const query: SearchQuery<Student> = {
+				facets: ["address.city"],
+			};
+			Utility.protoSearchRequestFromQuery(query, request);
+
+			expect(request.getFacet()).toEqual(
+				Utility.stringToUint8Array('{"address.city":{"size":10,"type":"value"}}')
+			);
+		});
+
+		it("sets sort order", () => {
+			const query: SearchQuery<Student> = {
+				sort: { field: "field_1", order: Order.DESC },
+			};
+			Utility.protoSearchRequestFromQuery(query, request);
+
+			expect(request.getSort()).toEqual(Utility.stringToUint8Array('[{"field_1":"$desc"}]'));
+		});
+
+		it("sets includeFields", () => {
+			const query: SearchQuery<Student> = { includeFields: ["name", "address.street"] };
+			Utility.protoSearchRequestFromQuery(query, request);
+
+			expect(request.getIncludeFieldsList()).toEqual(["name", "address.street"]);
+		});
+
+		it("sets excludeFields", () => {
+			const query: SearchQuery<Student> = { excludeFields: ["name", "address.street"] };
+			Utility.protoSearchRequestFromQuery(query, request);
+
+			expect(request.getExcludeFieldsList()).toEqual(["name", "address.street"]);
+		});
+
+		it("sets hitsPerPage", () => {
+			const query: SearchQuery<Student> = { hitsPerPage: 57 };
+			Utility.protoSearchRequestFromQuery(query, request);
+
+			expect(request.getPageSize()).toEqual(57);
+		});
+
+		it("sets page", () => {
+			Utility.protoSearchRequestFromQuery({}, request, 3);
+
+			expect(request.getPage()).toEqual(3);
 		});
 
 		it("sets collation options", () => {
@@ -125,81 +176,77 @@ describe("utility tests", () => {
 					case: Case.CaseInsensitive,
 				},
 			};
-			const emptyRequest = { q: "", options: options };
-			const generated = Utility.createProtoSearchRequest(
-				dbName,
-				branch,
-				collectionName,
-				emptyRequest
-			);
-			expect(generated.getPage()).toBe(0);
-			expect(generated.getPageSize()).toBe(0);
-			expect(generated.getCollation().getCase()).toBe("ci");
+			const optionsQuery = { q: "", options: options };
+			Utility.protoSearchRequestFromQuery(optionsQuery, request);
+
+			expect(request.getPage()).toBe(0);
+			expect(request.getPageSize()).toBe(0);
+			expect(request.getCollation().getCase()).toBe("ci");
+		});
+	});
+
+	const nerfingTestCases = [
+		["main/fork", "main_fork"],
+		["main-fork", "main-fork"],
+		["main?fork", "main?fork"],
+		["sTaging21", "sTaging21"],
+		["hotfix/jira-23$4", "hotfix_jira-23$4"],
+		["", ""],
+		["release", "release"],
+		["zero ops", "zero_ops"],
+		["under_score", "under_score"],
+		["bot/fork1.2#server/main_beta new", "bot_fork1.2_server_main_beta_new"],
+	];
+
+	test.each(nerfingTestCases)("nerfs the name - '%s'", (original, nerfed) => {
+		expect(Utility.nerfGitBranchName(original)).toBe(nerfed);
+	});
+
+	describe("character encoding", () => {
+		it("read back data into utf-8", () => {
+			expect(Utility._base64Decode("4KSo4KSu4KS44KWN4KSk4KWH")).toBe("नमस्ते");
+			expect(Utility._base64Decode("0L/RgNC40LLQtdGC")).toBe("привет");
+			expect(Utility._base64Decode("44GT44KT44Gr44Gh44Gv")).toBe("こんにちは");
+			expect(Utility._base64Decode("7JWI64WV7ZWY7IS47JqU")).toBe("안녕하세요");
+			expect(Utility._base64Decode("8J+Zjw==")).toBe("🙏");
+			expect(Utility._base64Decode("8J+YgQ==")).toBe("😁");
+		});
+	});
+
+	describe("get branch name from environment", () => {
+		const OLD_ENV = Object.assign({}, process.env);
+
+		beforeEach(() => {
+			jest.resetModules();
 		});
 
-		const nerfingTestCases = [
-			["main/fork", "main_fork"],
-			["main-fork", "main-fork"],
-			["main?fork", "main?fork"],
-			["sTaging21", "sTaging21"],
-			["hotfix/jira-23$4", "hotfix_jira-23$4"],
+		afterEach(() => {
+			process.env = OLD_ENV;
+		});
+
+		it.each([
+			["preview_${GIT_BRANCH}", "GIT_BRANCH", "feature_1", "preview_feature_1"],
+			["staging", undefined, undefined, "staging"],
+			["integration_${MY_VAR}_auto", undefined, undefined, undefined],
+			["integration_${MY_VAR}_auto", "NOT_SET", "feature_2", undefined],
+			["${MY_GIT_BRANCH}", "MY_GIT_BRANCH", "jira/1234", "jira_1234"],
+			["${MY_GIT_BRANCH", "MY_GIT_BRANCH", "jira/1234", "${MY_GIT_BRANCH"],
+			[undefined, undefined, undefined, undefined],
+		])("envVar - '%s'", (branchEnvValue, templateEnvKey, templateEnvValue, expected) => {
+			process.env["TIGRIS_DB_BRANCH"] = branchEnvValue;
+			if (templateEnvKey) {
+				process.env[templateEnvKey] = templateEnvValue;
+			}
+			expect(Utility.branchNameFromEnv()).toEqual(expected);
+		});
+
+		it.each([
+			["any_given_branch", "any_given_branch"],
 			["", ""],
-			["release", "release"],
-			["zero ops", "zero_ops"],
-			["under_score", "under_score"],
-			["bot/fork1.2#server/main_beta new", "bot_fork1.2_server_main_beta_new"],
-		];
-
-		test.each(nerfingTestCases)("nerfs the name - '%s'", (original, nerfed) => {
-			expect(Utility.nerfGitBranchName(original)).toBe(nerfed);
-		});
-
-		describe("character encoding", () => {
-			it("read back data into utf-8", () => {
-				expect(Utility._base64Decode("4KSo4KSu4KS44KWN4KSk4KWH")).toBe("नमस्ते");
-				expect(Utility._base64Decode("0L/RgNC40LLQtdGC")).toBe("привет");
-				expect(Utility._base64Decode("44GT44KT44Gr44Gh44Gv")).toBe("こんにちは");
-				expect(Utility._base64Decode("7JWI64WV7ZWY7IS47JqU")).toBe("안녕하세요");
-				expect(Utility._base64Decode("8J+Zjw==")).toBe("🙏");
-				expect(Utility._base64Decode("8J+YgQ==")).toBe("😁");
-			});
-		});
-
-		describe("get branch name from environment", () => {
-			const OLD_ENV = Object.assign({}, process.env);
-
-			beforeEach(() => {
-				jest.resetModules();
-			});
-
-			afterEach(() => {
-				process.env = OLD_ENV;
-			});
-
-			it.each([
-				["preview_${GIT_BRANCH}", "GIT_BRANCH", "feature_1", "preview_feature_1"],
-				["staging", undefined, undefined, "staging"],
-				["integration_${MY_VAR}_auto", undefined, undefined, undefined],
-				["integration_${MY_VAR}_auto", "NOT_SET", "feature_2", undefined],
-				["${MY_GIT_BRANCH}", "MY_GIT_BRANCH", "jira/1234", "jira_1234"],
-				["${MY_GIT_BRANCH", "MY_GIT_BRANCH", "jira/1234", "${MY_GIT_BRANCH"],
-				[undefined, undefined, undefined, undefined],
-			])("envVar - '%s'", (branchEnvValue, templateEnvKey, templateEnvValue, expected) => {
-				process.env["TIGRIS_DB_BRANCH"] = branchEnvValue;
-				if (templateEnvKey) {
-					process.env[templateEnvKey] = templateEnvValue;
-				}
-				expect(Utility.branchNameFromEnv()).toEqual(expected);
-			});
-
-			it.each([
-				["any_given_branch", "any_given_branch"],
-				["", ""],
-				[undefined, undefined],
-			])("given branch - '%s'", (givenBranch, expected) => {
-				const actual = Utility.branchNameFromEnv(givenBranch);
-				expect(actual).toBe(expected);
-			});
+			[undefined, undefined],
+		])("given branch - '%s'", (givenBranch, expected) => {
+			const actual = Utility.branchNameFromEnv(givenBranch);
+			expect(actual).toBe(expected);
 		});
 	});
 });

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -1,5 +1,5 @@
 import { Utility } from "../utility";
-import { Order, SelectorFilterOperator, SortOrder } from "../types";
+import { SelectorFilterOperator, SortOrder } from "../types";
 import {
 	Case,
 	FacetFieldOptions,
@@ -74,16 +74,12 @@ describe("utility tests", () => {
 		[
 			"multiple sort fields",
 			[
-				{ field: "name", order: Order.ASC },
-				{ field: "address.street", order: Order.DESC },
+				{ field: "name", order: "$asc" },
+				{ field: "address.street", order: "$desc" },
 			],
 			'[{"name":"$asc"},{"address.street":"$desc"}]',
 		],
-		[
-			"single sort field",
-			{ field: "address.city", order: Order.DESC },
-			'[{"address.city":"$desc"}]',
-		],
+		["single sort field", { field: "address.city", order: "$desc" }, '[{"address.city":"$desc"}]'],
 		["empty array", [], "[]"],
 	])("_sortOrderingToString() with '%s'", (testName, input, expected: string) => {
 		expect(Utility._sortOrderingToString(input)).toBe(expected);
@@ -139,7 +135,7 @@ describe("utility tests", () => {
 
 		it("sets sort order", () => {
 			const query: SearchQuery<Student> = {
-				sort: { field: "balance", order: Order.DESC },
+				sort: { field: "balance", order: "$desc" },
 			};
 			Utility.protoSearchRequestFromQuery(query, request);
 

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -85,6 +85,17 @@ describe("utility tests", () => {
 		const branch = "my_test_branch";
 		const collectionName = "my_test_collection";
 
+		it("sets query string to match all if not provided", () => {
+			const emptyRequest = {};
+			const generated = Utility.createProtoSearchRequest(
+				dbName,
+				branch,
+				collectionName,
+				emptyRequest
+			);
+			expect(generated.getQ()).toBe("");
+		});
+
 		it("populates projectName and collection name", () => {
 			const emptyRequest = { q: "" };
 			const generated = Utility.createProtoSearchRequest(

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -1,5 +1,5 @@
 import { Utility } from "../utility";
-import { LogicalOperator, Order, SelectorFilterOperator } from "../types";
+import { Order, SelectorFilterOperator, SortOrder } from "../types";
 import {
 	Case,
 	FacetFieldOptions,
@@ -13,7 +13,6 @@ import {
 import { SearchRequest as ProtoSearchRequest } from "../proto/server/v1/api_pb";
 import { TigrisCollection } from "../decorators/tigris-collection";
 import { PrimaryKey } from "../decorators/tigris-primary-key";
-import * as stream from "stream";
 import { Field } from "../decorators/tigris-field";
 
 describe("utility tests", () => {
@@ -70,19 +69,23 @@ describe("utility tests", () => {
 		expect(serializedFields).toBe(Utility.facetQueryToString(facetWithOptions));
 	});
 
-	it.each([
+	it.each<[string, SortOrder<Student>, string]>([
 		["undefined", undefined, "[]"],
 		[
 			"multiple sort fields",
 			[
-				{ field: "field_1", order: Order.ASC },
-				{ field: "parent.field_2", order: Order.DESC },
+				{ field: "name", order: Order.ASC },
+				{ field: "address.street", order: Order.DESC },
 			],
-			'[{"field_1":"$asc"},{"parent.field_2":"$desc"}]',
+			'[{"name":"$asc"},{"address.street":"$desc"}]',
 		],
-		["single sort field", { field: "field_3", order: Order.DESC }, '[{"field_3":"$desc"}]'],
+		[
+			"single sort field",
+			{ field: "address.city", order: Order.DESC },
+			'[{"address.city":"$desc"}]',
+		],
 		["empty array", [], "[]"],
-	])("_sortOrderingToString() with '%s'", (testName, input, expected) => {
+	])("_sortOrderingToString() with '%s'", (testName, input, expected: string) => {
 		expect(Utility._sortOrderingToString(input)).toBe(expected);
 	});
 
@@ -136,11 +139,11 @@ describe("utility tests", () => {
 
 		it("sets sort order", () => {
 			const query: SearchQuery<Student> = {
-				sort: { field: "field_1", order: Order.DESC },
+				sort: { field: "balance", order: Order.DESC },
 			};
 			Utility.protoSearchRequestFromQuery(query, request);
 
-			expect(request.getSort()).toEqual(Utility.stringToUint8Array('[{"field_1":"$desc"}]'));
+			expect(request.getSort()).toEqual(Utility.stringToUint8Array('[{"balance":"$desc"}]'));
 		});
 
 		it("sets includeFields", () => {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -6,6 +6,7 @@ import {
 	InsertRequest as ProtoInsertRequest,
 	ReadRequest as ProtoReadRequest,
 	ReplaceRequest as ProtoReplaceRequest,
+	SearchRequest as ProtoSearchRequest,
 	SearchResponse as ProtoSearchResponse,
 	UpdateRequest as ProtoUpdateRequest,
 } from "./proto/server/v1/api_pb";
@@ -676,13 +677,12 @@ export class Collection<T extends TigrisCollectionType> implements ICollection {
 	search(query: SearchQuery<T>, page: number): Promise<SearchResult<T>>;
 
 	search(query: SearchQuery<T>, page?: number): SearchIterator<T> | Promise<SearchResult<T>> {
-		const searchRequest = Utility.createProtoSearchRequest(
-			this.db,
-			this.branch,
-			this.collectionName,
-			query,
-			page
-		);
+		const searchRequest = new ProtoSearchRequest()
+			.setProject(this.db)
+			.setBranch(this.branch)
+			.setCollection(this.collectionName);
+
+		Utility.protoSearchRequestFromQuery(query, searchRequest, page);
 
 		// return a iterator if no explicit page number is specified
 		if (typeof page === "undefined") {

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -25,7 +25,7 @@ export interface SearchQuery<T extends TigrisCollectionType> {
 	/**
 	 * Sort the search results in indicated order
 	 */
-	sort?: SortOrder;
+	sort?: SortOrder<T>;
 	/**
 	 * Document fields to include when returning search results
 	 */

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -9,7 +9,7 @@ export interface SearchQuery<T extends TigrisCollectionType> {
 	/**
 	 * Text to match
 	 */
-	q: string;
+	q?: string;
 	/**
 	 * Fields to project search query on
 	 */

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -1,4 +1,4 @@
-import { Filter, SortOrder, TigrisCollectionType } from "../types";
+import { Filter, Paths, SortOrder, TigrisCollectionType } from "../types";
 
 export const MATCH_ALL_QUERY_STRING = "";
 
@@ -21,7 +21,7 @@ export interface SearchQuery<T extends TigrisCollectionType> {
 	/**
 	 * Facet fields to categorically arrange indexed terms
 	 */
-	facets?: FacetFieldsQuery;
+	facets?: FacetFieldsQuery<T>;
 	/**
 	 * Sort the search results in indicated order
 	 */
@@ -55,19 +55,19 @@ export interface SearchQueryOptions {
 	collation?: Collation;
 }
 
-export type FacetFieldsQuery = FacetFieldOptions | FacetFields;
+export type FacetFieldsQuery<T> = FacetFieldOptions<T> | FacetFields<T>;
 
 /**
  * Map of collection field names and faceting options to include facet results in search response
  */
-export type FacetFieldOptions = {
-	[key: string]: FacetQueryOptions;
-};
+export type FacetFieldOptions<T> = Partial<{
+	[K in Paths<T>]: FacetQueryOptions;
+}>;
 
 /**
  * Array of field names to include facet results for in search response
  */
-export type FacetFields = Array<string>;
+export type FacetFields<T> = Partial<Paths<T>>[];
 
 /**
  * Information to build facets in search results

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -1,11 +1,12 @@
 import { DocumentFields, DocumentPaths, Filter, SortOrder, TigrisCollectionType } from "../types";
+import { TigrisIndexType } from "./types";
 
 export const MATCH_ALL_QUERY_STRING = "";
 
 /**
  * Search query builder
  */
-export interface SearchQuery<T extends TigrisCollectionType> {
+export interface SearchQuery<T extends TigrisCollectionType | TigrisIndexType> {
 	/**
 	 * Text to match
 	 */

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -1,4 +1,4 @@
-import { Filter, Paths, SortOrder, TigrisCollectionType } from "../types";
+import { DocumentFields, DocumentPaths, Filter, SortOrder, TigrisCollectionType } from "../types";
 
 export const MATCH_ALL_QUERY_STRING = "";
 
@@ -13,7 +13,7 @@ export interface SearchQuery<T extends TigrisCollectionType> {
 	/**
 	 * Fields to project search query on
 	 */
-	searchFields?: Array<string>;
+	searchFields?: DocumentPaths<T>;
 	/**
 	 * Filter to further refine the search results
 	 */
@@ -29,11 +29,11 @@ export interface SearchQuery<T extends TigrisCollectionType> {
 	/**
 	 * Document fields to include when returning search results
 	 */
-	includeFields?: Array<string>;
+	includeFields?: DocumentPaths<T>;
 	/**
 	 * Document fields to exclude when returning search results
 	 */
-	excludeFields?: Array<string>;
+	excludeFields?: DocumentPaths<T>;
 	/**
 	 * Maximum number of search hits (matched documents) to fetch per page
 	 */
@@ -60,14 +60,12 @@ export type FacetFieldsQuery<T> = FacetFieldOptions<T> | FacetFields<T>;
 /**
  * Map of collection field names and faceting options to include facet results in search response
  */
-export type FacetFieldOptions<T> = Partial<{
-	[K in Paths<T>]: FacetQueryOptions;
-}>;
+export type FacetFieldOptions<T> = DocumentFields<T, FacetQueryOptions>;
 
 /**
  * Array of field names to include facet results for in search response
  */
-export type FacetFields<T> = Partial<Paths<T>>[];
+export type FacetFields<T> = DocumentPaths<T>;
 
 /**
  * Information to build facets in search results

--- a/src/search/search-index.ts
+++ b/src/search/search-index.ts
@@ -15,8 +15,7 @@ import { Utility } from "../utility";
 import { Filter } from "../types";
 import { SearchIndexIteratorInitializer, SearchIterator } from "../consumables/search-iterator";
 import * as grpc from "@grpc/grpc-js";
-import { Collation as ProtoCollation } from "../proto/server/v1/api_pb";
-import { MATCH_ALL_QUERY_STRING, SearchQuery } from "./query";
+import { SearchQuery } from "./query";
 import { IndexedDoc, SearchResult } from "./result";
 
 export class SearchIndex<T extends TigrisIndexType> {
@@ -219,44 +218,9 @@ export class SearchIndex<T extends TigrisIndexType> {
 	search(query: SearchQuery<T>, page?: number): SearchIterator<T> | Promise<SearchResult<T>> {
 		const searchRequest = new ProtoSearchIndexRequest()
 			.setProject(this.config.projectName)
-			.setIndex(this.name)
-			.setQ(query.q ?? MATCH_ALL_QUERY_STRING);
+			.setIndex(this.name);
 
-		if (query.searchFields !== undefined) {
-			searchRequest.setSearchFieldsList(query.searchFields);
-		}
-
-		if (query.filter !== undefined) {
-			searchRequest.setFilter(Utility.stringToUint8Array(Utility.filterToString(query.filter)));
-		}
-
-		if (query.facets !== undefined) {
-			searchRequest.setFacet(Utility.stringToUint8Array(Utility.facetQueryToString(query.facets)));
-		}
-
-		if (query.sort !== undefined) {
-			searchRequest.setSort(Utility.stringToUint8Array(Utility._sortOrderingToString(query.sort)));
-		}
-
-		if (query.includeFields !== undefined) {
-			searchRequest.setIncludeFieldsList(query.includeFields);
-		}
-
-		if (query.excludeFields !== undefined) {
-			searchRequest.setExcludeFieldsList(query.excludeFields);
-		}
-
-		if (query.hitsPerPage !== undefined) {
-			searchRequest.setPageSize(query.hitsPerPage);
-		}
-
-		if (query.options?.collation !== undefined) {
-			searchRequest.setCollation(new ProtoCollation().setCase(query.options.collation.case));
-		}
-
-		if (page !== undefined) {
-			searchRequest.setPage(page);
-		}
+		Utility.protoSearchRequestFromQuery(query, searchRequest, page);
 
 		// return a iterator if no explicit page number is specified
 		if (typeof page === "undefined") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -678,7 +678,7 @@ export type PrimaryKeyOptions = {
  * and Paths<IUser> will make these keys available name, id, address (object type) and also in the
  * string form "name", "id", "address.city", "address.state"
  */
-type Paths<T, P extends string = ""> = {
+export type Paths<T, P extends string = ""> = {
 	[K in keyof T]: T[K] extends object
 		? T[K] extends unknown[]
 			? `${P}${K & string}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -486,14 +486,10 @@ export type ReadFields = {
 	exclude?: Array<string>;
 };
 
-type DocumentFields<T, V> = Partial<{
-	[K in Paths<T>]: V;
-}>;
-
 export type UpdateFields<T> =
 	| {
 			$set?: DocumentFields<T, FieldTypes | undefined>;
-			$unset?: Partial<Paths<T>>[];
+			$unset?: DocumentPaths<T>;
 			$increment?: DocumentFields<T, NumericType>;
 			$decrement?: DocumentFields<T, NumericType>;
 			$multiply?: DocumentFields<T, NumericType>;
@@ -698,6 +694,12 @@ type PathType<T, P extends string> = P extends keyof T
 		? PathType<T[L], R>
 		: never
 	: never;
+
+export type DocumentFields<T, V> = Partial<{
+	[K in Paths<T>]: V;
+}>;
+
+export type DocumentPaths<T> = Partial<Paths<T>>[];
 
 export type Selector<T> = Partial<{
 	[K in Paths<T>]: Partial<PathType<T, K & string>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -507,20 +507,12 @@ export type SortOrder<T> = SortField<T> | Array<SortField<T>>;
  */
 export type SortField<T> = {
 	field: Paths<T>;
-	order: Order;
+
+	/**
+	 * Ascending or Descending order
+	 */
+	order: "$asc" | "$desc";
 };
-
-export enum Order {
-	/**
-	 * Ascending order
-	 */
-	ASC = "$asc",
-
-	/**
-	 * Descending order
-	 */
-	DESC = "$desc",
-}
 
 /**
  * Query builder for reading documents from a collection

--- a/src/types.ts
+++ b/src/types.ts
@@ -500,13 +500,13 @@ export type UpdateFields<T> =
 /**
  * List of fields and their corresponding sort order to order the search results.
  */
-export type SortOrder = SortField | Array<SortField>;
+export type SortOrder<T> = SortField<T> | Array<SortField<T>>;
 
 /**
  * Collection field name and sort order
  */
-export type SortField = {
-	field: string;
+export type SortField<T> = {
+	field: Paths<T>;
 	order: Order;
 };
 
@@ -541,7 +541,7 @@ export interface FindQuery<T> {
 	/**
 	 * Sort the query results as per indicated order
 	 */
-	sort?: SortOrder;
+	sort?: SortOrder<T>;
 
 	/**
 	 * Optional params

--- a/src/types.ts
+++ b/src/types.ts
@@ -481,9 +481,9 @@ export enum SelectorFilterOperator {
 export type NumericType = number | bigint;
 export type FieldTypes = string | boolean | NumericType | BigInteger | Date;
 
-export type ReadFields = {
-	include?: Array<string>;
-	exclude?: Array<string>;
+export type ReadFields<T> = {
+	include?: DocumentPaths<T>;
+	exclude?: DocumentPaths<T>;
 };
 
 export type UpdateFields<T> =
@@ -536,7 +536,7 @@ export interface FindQuery<T> {
 	 * Field projection to allow returning only specific document fields. By default
 	 * all document fields are returned.
 	 */
-	readFields?: ReadFields;
+	readFields?: ReadFields<T>;
 
 	/**
 	 * Sort the query results as per indicated order

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -556,7 +556,7 @@ export const Utility = {
 		}
 	},
 
-	_sortOrderingToString(ordering: SortOrder): string {
+	_sortOrderingToString<T>(ordering: SortOrder<T>): string {
 		if (typeof ordering === "undefined") {
 			return "[]";
 		}

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -164,11 +164,22 @@ export const Utility = {
 		return result;
 	},
 
-	readFieldString(readFields: ReadFields): string {
-		const include = readFields.include?.reduce((acc, field) => ({ ...acc, [field]: true }), {});
-		const exclude = readFields.exclude?.reduce((acc, field) => ({ ...acc, [field]: false }), {});
+	readFieldString<T>(readFields: ReadFields<T>): string {
+		const readFieldsObj = {};
 
-		return this.objToJsonString({ ...include, ...exclude });
+		if (readFields.include) {
+			for (const f of readFields.include) {
+				readFieldsObj[f.toString()] = true;
+			}
+		}
+
+		if (readFields.exclude) {
+			for (const f of readFields.exclude) {
+				readFieldsObj[f.toString()] = false;
+			}
+		}
+
+		return this.objToJsonString(readFieldsObj);
 	},
 
 	updateFieldsString<T>(updateFields: UpdateFields<T>) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -531,11 +531,11 @@ export const Utility = {
 		return { ...defaults, ...options };
 	},
 
-	facetQueryToString(facets: FacetFieldsQuery): string {
+	facetQueryToString<T>(facets: FacetFieldsQuery<T>): string {
 		if (Array.isArray(facets)) {
 			const optionsMap = {};
 			for (const f of facets) {
-				optionsMap[f] = this.createFacetQueryOptions();
+				optionsMap[f.toString()] = this.createFacetQueryOptions();
 			}
 			return this.objToJsonString(optionsMap);
 		} else {


### PR DESCRIPTION
## Describe your changes

#### 1. `q` in SearchQuery is optional ( closes #269 )

```diff
- const matchAll: SearchQuery<Student> = { q: "" };
+ const matchAll: SearchQuery<Student> = { };
```


#### 2. Querying constructs are bound to schema fields ( closes #267 )
```diff
- searchFields?: Array<string>;
+ searchFields?: DocumentPaths<T>;

- includeFields?: Array<string>;
+ includeFields?: DocumentPaths<T>;

- excludeFields?: Array<string>;
+ excludeFields?: DocumentPaths<T>;

- export type FacetFieldOptions = {
- 	[key: string]: FacetQueryOptions;
- };
+ export type FacetFieldOptions<T> = DocumentFields<T, FacetQueryOptions>;

- export type FacetFields = Array<string>;
+ export type FacetFields<T> = DocumentPaths<T>;

- export type ReadFields = {
-	include?: Array<string>;
-	exclude?: Array<string>;
-};
+ export type ReadFields<T> = {
+	include?: DocumentPaths<T>;
+	exclude?: DocumentPaths<T>;
+};

-export type SortField = {
-	field: string;
-	order: Order;
-};
+export type SortField<T> = {
+	field: Paths<T>;
+	order: "$asc" | "$desc";
+};
```

This enables autocompletion in IDE and enables static type checks at compile time. Introduces compile time checking for cases where a schema field is renamed.


## How best to test these changes
Unit tests
