### PR TITLE
fix: Allow object types for updating a document

### DIFF
--- a/src/__tests__/tigris.updatefields.spec.ts
+++ b/src/__tests__/tigris.updatefields.spec.ts
@@ -2,7 +2,7 @@ import { Utility } from "../utility";
 import { TigrisCollection } from "../decorators/tigris-collection";
 import { PrimaryKey } from "../decorators/tigris-primary-key";
 import { Field } from "../decorators/tigris-field";
-import { UpdateFields, UpdateQuery } from "../types";
+import { TigrisDataTypes, UpdateFields } from "../types";
 
 describe("updateFields tests", () => {
 	const testCases: Array<{
@@ -33,14 +33,14 @@ describe("updateFields tests", () => {
 		{
 			name: "all operators",
 			input: {
-				$set: { category: "New category" },
+				$set: { title: "Kite Runner" },
 				$unset: ["publisher.name", "active"],
 				$multiply: { rating: 2.2 },
 				$decrement: { quantity: 1, price: 3.53 },
 				$increment: { "publisher.totalPublished": 1, price: 4.1 },
 			},
 			expected:
-				'{"$set":{"category":"New category"},"$unset":["publisher.name","active"],"$multiply":{"rating":2.2},"$decrement":{"quantity":1,"price":3.53},"$increment":{"publisher.totalPublished":1,"price":4.1}}',
+				'{"$set":{"title":"Kite Runner"},"$unset":["publisher.name","active"],"$multiply":{"rating":2.2},"$decrement":{"quantity":1,"price":3.53},"$increment":{"publisher.totalPublished":1,"price":4.1}}',
 		},
 		{
 			name: "division update only",
@@ -52,9 +52,16 @@ describe("updateFields tests", () => {
 		{
 			name: "setting field to an object",
 			input: {
-				publisher: { totalPublished: 24, name: "Robert" } as Publisher,
+				publisher: { totalPublished: 24, name: "Urban books" } as Publisher,
 			},
-			expected: '{"$set":{"publisher":{"totalPublished":24,"name":"Robert"}}}',
+			expected: '{"$set":{"publisher":{"totalPublished":24,"name":"Urban books"}}}',
+		},
+		{
+			name: "setting update fields to an array",
+			input: {
+				categories: ["tales", "stories"],
+			},
+			expected: '{"$set":{"categories":["tales","stories"]}}',
 		},
 	];
 
@@ -88,8 +95,8 @@ class Books {
 	@Field()
 	quantity: number;
 
-	@Field()
-	category: string;
+	@Field({ elements: TigrisDataTypes.STRING })
+	categories: string[];
 
 	@Field()
 	rating: number;

--- a/src/__tests__/tigris.updatefields.spec.ts
+++ b/src/__tests__/tigris.updatefields.spec.ts
@@ -2,7 +2,7 @@ import { Utility } from "../utility";
 import { TigrisCollection } from "../decorators/tigris-collection";
 import { PrimaryKey } from "../decorators/tigris-primary-key";
 import { Field } from "../decorators/tigris-field";
-import { UpdateFields } from "../types";
+import { UpdateFields, UpdateQuery } from "../types";
 
 describe("updateFields tests", () => {
 	const testCases: Array<{
@@ -48,6 +48,13 @@ describe("updateFields tests", () => {
 				$divide: { rating: 2.34 },
 			},
 			expected: '{"$divide":{"rating":2.34}}',
+		},
+		{
+			name: "setting field to an object",
+			input: {
+				publisher: { totalPublished: 24, name: "Robert" } as Publisher,
+			},
+			expected: '{"$set":{"publisher":{"totalPublished":24,"name":"Robert"}}}',
 		},
 	];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -479,7 +479,7 @@ export enum SelectorFilterOperator {
 }
 
 export type NumericType = number | bigint;
-export type FieldTypes = string | boolean | NumericType | BigInteger | Date;
+export type FieldTypes = string | boolean | NumericType | BigInteger | Date | object;
 
 export type ReadFields<T> = {
 	include?: DocumentPaths<T>;


### PR DESCRIPTION
## Describe your changes
- Allows setting embedded documents and arrays in update fields
```ts
const updatedPublisher: Publisher = {
    totalPublished: 24,
    name: "Urban books"
}

const publisherUpdate: UpdateFields<Books> = {
    $set: {
        publisher: updatedPublisher
    }
}

const categoryUpdate: UpdateFields<Books> = {
    $set: {
        categories: ["classic", "literature"]
    }
}
```

## How best to test these changes
- Unit tests

## Issue ticket number and link
closes #271 