### PR TITLE
fix: Empty properties obj on free flow objects

### DIFF
--- a/src/__tests__/fixtures/json-schema/vacationRentals.json
+++ b/src/__tests__/fixtures/json-schema/vacationRentals.json
@@ -57,6 +57,7 @@
 		},
 		"verifications": {
 			"type": "object",
+			"properties": {},
 			"default": {
 				"stateId": true
 			}
@@ -77,12 +78,14 @@
 		},
 		"host": {
 			"type": "object",
+			"properties": {},
 			"default": null
 		},
 		"reviews": {
 			"type": "array",
 			"items": {
-				"type": "object"
+				"type": "object",
+				"properties": {}
 			},
 			"default": null
 		},

--- a/src/__tests__/fixtures/schema/vacationRentals.ts
+++ b/src/__tests__/fixtures/schema/vacationRentals.ts
@@ -62,7 +62,7 @@ export class VacationRentals {
 	attractions: Array<string>;
 
 	@Field({ default: null })
-	host: Object;
+	host: object;
 
 	@Field({ elements: TigrisDataTypes.OBJECT, default: undefined })
 	reviews: Array<Object>;

--- a/src/__tests__/tigris.schema.spec.ts
+++ b/src/__tests__/tigris.schema.spec.ts
@@ -2,8 +2,8 @@ import { CollectionSchema, DecoratedSchemaProcessor } from "../schema/decorated-
 import { TigrisCollectionType, TigrisSchema } from "../types";
 import { User, USERS_COLLECTION_NAME, UserSchema } from "./fixtures/schema/users";
 import {
-	VacationRentals,
 	RENTALS_COLLECTION_NAME,
+	VacationRentals,
 	VacationsRentalSchema,
 } from "./fixtures/schema/vacationRentals";
 import { Field } from "../decorators/tigris-field";

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -345,6 +345,9 @@ export const Utility = {
 					pkeyMap,
 					keyMap
 				);
+			} else if (schema[property].type === TigrisDataTypes.OBJECT) {
+				thisProperty["type"] = "object";
+				thisProperty["properties"] = {};
 			} else if (
 				schema[property].type != TigrisDataTypes.ARRAY.valueOf() &&
 				typeof schema[property].type != "object"


### PR DESCRIPTION
## Describe your changes
- Free flow objects were not including empty `properties: {}` on serializing the schema

## How best to test these changes
- Unit tests

