### PR TITLE
fix: Fix for json-bigint bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,14 @@
 				"chalk": "4.1.2",
 				"dotenv": "^16.0.3",
 				"google-protobuf": "^3.21.0",
-				"json-bigint": "^1.0.0",
+				"json-bigint": "github:sidorares/json-bigint",
 				"reflect-metadata": "^0.1.13",
 				"typescript": "^4.7.2"
 			},
 			"devDependencies": {
 				"@semantic-release/npm": "^9.0.1",
 				"@types/jest": "^28.1.8",
+				"@types/json-bigint": "^1.0.1",
 				"@typescript-eslint/eslint-plugin": "^5.35.1",
 				"@typescript-eslint/parser": "^5.35.1",
 				"copyfiles": "^2.4.1",
@@ -1950,6 +1951,12 @@
 				"expect": "^28.0.0",
 				"pretty-format": "^28.0.0"
 			}
+		},
+		"node_modules/@types/json-bigint": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.1.tgz",
+			"integrity": "sha512-zpchZLNsNuzJHi6v64UBoFWAvQlPhch7XAi36FkH6tL1bbbmimIF+cS7vwkzY4u5RaSWMoflQfu+TshMPPw8uw==",
+			"dev": true
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
@@ -6020,8 +6027,8 @@
 		},
 		"node_modules/json-bigint": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"resolved": "git+ssh://git@github.com/sidorares/json-bigint.git#3391780b2a3f613bb51536c47e6cddbca31013eb",
+			"license": "MIT",
 			"dependencies": {
 				"bignumber.js": "^9.0.0"
 			}
@@ -13003,6 +13010,12 @@
 				"pretty-format": "^28.0.0"
 			}
 		},
+		"@types/json-bigint": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.1.tgz",
+			"integrity": "sha512-zpchZLNsNuzJHi6v64UBoFWAvQlPhch7XAi36FkH6tL1bbbmimIF+cS7vwkzY4u5RaSWMoflQfu+TshMPPw8uw==",
+			"dev": true
+		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -16063,9 +16076,8 @@
 			"dev": true
 		},
 		"json-bigint": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"version": "git+ssh://git@github.com/sidorares/json-bigint.git#3391780b2a3f613bb51536c47e6cddbca31013eb",
+			"from": "json-bigint@github:sidorares/json-bigint",
 			"requires": {
 				"bignumber.js": "^9.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 	"devDependencies": {
 		"@semantic-release/npm": "^9.0.1",
 		"@types/jest": "^28.1.8",
+		"@types/json-bigint": "^1.0.1",
 		"@typescript-eslint/eslint-plugin": "^5.35.1",
 		"@typescript-eslint/parser": "^5.35.1",
 		"eslint-plugin-tsdoc": "0.2.17",
@@ -110,7 +111,7 @@
 		"chalk": "4.1.2",
 		"dotenv": "^16.0.3",
 		"google-protobuf": "^3.21.0",
-		"json-bigint": "^1.0.0",
+		"json-bigint": "github:sidorares/json-bigint",
 		"reflect-metadata": "^0.1.13",
 		"typescript": "^4.7.2",
 		"app-root-path": "^3.1.0"

--- a/src/__tests__/tigris.jsonserde.spec.ts
+++ b/src/__tests__/tigris.jsonserde.spec.ts
@@ -7,23 +7,28 @@ describe("JSON serde tests", () => {
 			id: bigint;
 			name: string;
 			balance: number;
+			longitude: number;
 		}
 
 		const user: IUser = {
 			id: BigInt("9223372036854775807"),
 			name: "Alice",
 			balance: 123,
+			longitude: -73.96340000000001,
 		};
 		const userString = Utility.objToJsonString(user);
-		expect(userString).toBe('{"id":9223372036854775807,"name":"Alice","balance":123}');
+		expect(userString).toBe(
+			'{"id":9223372036854775807,"name":"Alice","balance":123,"longitude":-73.96340000000001}'
+		);
 
 		const deserializedUser = Utility.jsonStringToObj<IUser>(
-			'{"id":9223372036854775807,"name":"Alice","balance":123}',
+			'{"id":9223372036854775807,"name":"Alice","balance":123,"longitude":-73.96340000000001}',
 			{ serverUrl: "test" }
 		);
 		expect(deserializedUser.id).toBe("9223372036854775807");
 		expect(deserializedUser.name).toBe("Alice");
 		expect(deserializedUser.balance).toBe(123);
+		expect(deserializedUser.longitude).toBe(-73.96340000000001);
 	});
 
 	it("jsonSerDeStringAsBigInt", () => {


### PR DESCRIPTION
fix: Fix for json-bigint bug https://github.com/sidorares/json-bigint/issues/49 where it tries to parse float numbers as BigInt

## Describe your changes

Use the fixed version of the library and add a test

## Test failure before the library update

Test failure before the library update

```
$ npx jest src/__tests__/tigris.jsonserde.spec.ts
 FAIL  src/__tests__/tigris.jsonserde.spec.ts
  JSON serde tests
    ✕ jsonSerDe (2 ms)
    ✓ jsonSerDeStringAsBigInt
    ✓ jsonSerDeNativeBigInt (1 ms)
    ✓ jsonSerDeNativeBigIntNested

  ● JSON serde tests › jsonSerDe

    SyntaxError: Cannot convert -73.96340000000001 to a BigInt
        at BigInt (<anonymous>)

      215 | 	jsonStringToObj<T>(json: string, config: TigrisClientConfig): T {
      216 | 		const JSONbigNative = json_bigint({ useNativeBigInt: true });
    > 217 | 		return JSONbigNative.parse(json, (k, v) => {
          | 		                     ^
      218 | 			// convert bigint to string based on configuration
      219 | 			if (typeof v === "bigint" && (config.supportBigInt === undefined || !config.supportBigInt)) {
      220 | 				return v.toString();
```

## Test passes after the library update

```
$ npx jest src/__tests__/tigris.jsonserde.spec.ts
 PASS  src/__tests__/tigris.jsonserde.spec.ts
  JSON serde tests
    ✓ jsonSerDe (2 ms)
    ✓ jsonSerDeStringAsBigInt (1 ms)
    ✓ jsonSerDeNativeBigInt
    ✓ jsonSerDeNativeBigIntNested
```
