### PR TITLE
Arrays of objects and nested arrays only support index related tags at the parent level

### DIFF
--- a/src/__tests__/fixtures/json-schema/orders.json
+++ b/src/__tests__/fixtures/json-schema/orders.json
@@ -27,8 +27,7 @@
 						"type": "object",
 						"properties": {
 							"name": {
-								"type": "string",
-								"searchIndex": true
+								"type": "string"
 							},
 							"tags": {
 								"type": "array",
@@ -42,10 +41,7 @@
 						"type": "integer"
 					},
 					"price": {
-						"type": "number",
-						"searchIndex": true,
-						"sort": true,
-						"facet": false
+						"type": "number"
 					}
 				}
 			}

--- a/src/__tests__/fixtures/json-schema/search/matrices.json
+++ b/src/__tests__/fixtures/json-schema/search/matrices.json
@@ -17,16 +17,13 @@
 						"type": "object",
 						"properties": {
 							"x": {
-								"type": "number",
-								"searchIndex": true
+								"type": "number"
 							},
 							"y": {
-								"type": "number",
-								"searchIndex": true
+								"type": "number"
 							},
 							"value": {
-								"type": "string",
-								"searchIndex": true
+								"type": "string"
 							}
 						}
 					}

--- a/src/__tests__/fixtures/json-schema/search/orders.json
+++ b/src/__tests__/fixtures/json-schema/search/orders.json
@@ -19,39 +19,46 @@
 				"type": "object",
 				"properties": {
 					"name": {
-						"type": "string",
-						"searchIndex": true
+						"type": "string"
 					},
 					"brand": {
 						"type": "object",
 						"properties": {
 							"name": {
-								"type": "string",
-								"searchIndex": true
+								"type": "string"
 							},
 							"tags": {
 								"type": "array",
 								"items": {
 									"type": "string"
-								},
-								"searchIndex": false
+								}
 							}
 						}
 					},
 					"upc": {
-						"type": "integer",
-						"searchIndex": false,
-						"sort": false
+						"type": "integer"
 					},
 					"price": {
-						"type": "number",
-						"searchIndex": true,
-						"sort": true,
-						"facet": false
+						"type": "number"
 					}
 				}
 			},
 			"searchIndex": true
+		},
+		"status": {
+			"type": "object",
+			"properties": {
+				"statusType": {
+					"type": "string",
+					"searchIndex": true,
+					"facet": true
+				},
+				"createdAt": {
+					"type": "string",
+					"format": "date-time",
+					"searchIndex": true
+				}
+			}
 		}
 	}
 }

--- a/src/__tests__/fixtures/schema/orders.ts
+++ b/src/__tests__/fixtures/schema/orders.ts
@@ -91,7 +91,6 @@ export const OrderSchema: TigrisSchema<Order> = {
 					type: {
 						name: {
 							type: TigrisDataTypes.STRING,
-							searchIndex: true,
 						},
 						tags: {
 							type: TigrisDataTypes.ARRAY,
@@ -106,9 +105,6 @@ export const OrderSchema: TigrisSchema<Order> = {
 				},
 				price: {
 					type: TigrisDataTypes.NUMBER,
-					searchIndex: true,
-					sort: true,
-					facet: false,
 				},
 			},
 		},

--- a/src/__tests__/fixtures/schema/search/matrices.ts
+++ b/src/__tests__/fixtures/schema/search/matrices.ts
@@ -57,15 +57,12 @@ export const MatrixSchema: TigrisIndexSchema<Matrix> = {
 					type: {
 						x: {
 							type: TigrisDataTypes.NUMBER,
-							searchIndex: true,
 						},
 						y: {
 							type: TigrisDataTypes.NUMBER,
-							searchIndex: true,
 						},
 						value: {
 							type: TigrisDataTypes.STRING,
-							searchIndex: true,
 						},
 					},
 				},

--- a/src/__tests__/fixtures/schema/search/orders.ts
+++ b/src/__tests__/fixtures/schema/search/orders.ts
@@ -35,6 +35,14 @@ export class Product {
 	price: number;
 }
 
+export class OrderStatus {
+	@SearchField({ facet: true })
+	statusType: string;
+
+	@SearchField()
+	createdAt: Date;
+}
+
 @TigrisSearchIndex(ORDERS_INDEX_NAME)
 export class Order {
 	@SearchField(TigrisDataTypes.UUID, { sort: true })
@@ -45,6 +53,9 @@ export class Order {
 
 	@SearchField({ elements: Product })
 	products: Array<Product>;
+
+	@SearchField()
+	status: OrderStatus;
 }
 
 /**
@@ -71,17 +82,14 @@ export const OrderSchema: TigrisIndexSchema<Order> = {
 			type: {
 				name: {
 					type: TigrisDataTypes.STRING,
-					searchIndex: true,
 				},
 				brand: {
 					type: {
 						name: {
 							type: TigrisDataTypes.STRING,
-							searchIndex: true,
 						},
 						tags: {
 							type: TigrisDataTypes.ARRAY,
-							searchIndex: false,
 							items: {
 								type: TigrisDataTypes.STRING,
 							},
@@ -90,15 +98,23 @@ export const OrderSchema: TigrisIndexSchema<Order> = {
 				},
 				upc: {
 					type: TigrisDataTypes.NUMBER_BIGINT,
-					searchIndex: false,
-					sort: false,
 				},
 				price: {
 					type: TigrisDataTypes.NUMBER,
-					searchIndex: true,
-					sort: true,
-					facet: false,
 				},
+			},
+		},
+	},
+	status: {
+		type: {
+			statusType: {
+				type: TigrisDataTypes.STRING,
+				searchIndex: true,
+				facet: true,
+			},
+			createdAt: {
+				type: TigrisDataTypes.DATE_TIME,
+				searchIndex: true,
 			},
 		},
 	},


### PR DESCRIPTION
Arrays of objects and nested arrays only support index-related tags at the parent level.

```
// { "field1": { "type": "object", "properties": { "name": { "type": "string" } }, "searchIndex": true } - not supported
// { "field1": { "type": "object", "properties": { "name": { "type": "string", "searchIndex": true } } } - supported
// searchIndex, sort and facet tags cannot be defined within a nested array
// { "field1": { "type": "array", "items": { "type": "object", "properties": { "name": { "type": "string", "searchIndex": true } } } } - not supported
// { "field1": { "type": "array", "items": { "type": "object", "properties": { "name": { "type": "string" } } }, "searchIndex": true } - supported
```

## Describe your changes

## How best to test these changes

Unit tests

## Issue ticket number and link
