### PR TITLE
feat: Vector fields and vector search query

### DIFF
--- a/src/__tests__/fixtures/json-schema/search/matrices.json
+++ b/src/__tests__/fixtures/json-schema/search/matrices.json
@@ -30,6 +30,13 @@
 				}
 			},
 			"searchIndex": true
+		},
+		"relevance": {
+			"type": "array",
+			"dimensions": 4,
+			"format": "vector",
+			"searchIndex": true,
+			"sort": false
 		}
 	}
 }

--- a/src/__tests__/fixtures/json-schema/vacationRentals.json
+++ b/src/__tests__/fixtures/json-schema/vacationRentals.json
@@ -118,6 +118,12 @@
 			"type": "string",
 			"format": "uuid",
 			"default": "uuid()"
+		},
+		"relevance": {
+			"type": "array",
+			"dimensions": 3,
+			"format": "vector",
+			"default": [1.0, 1.0, 1.0]
 		}
 	},
 	"primary_key": ["id"]

--- a/src/__tests__/fixtures/schema/search/matrices.ts
+++ b/src/__tests__/fixtures/schema/search/matrices.ts
@@ -30,6 +30,9 @@ export class Matrix {
 
 	@SearchField({ elements: Cell, depth: 3 })
 	cells: Cell[][][];
+
+	@SearchField({ dimensions: 4, sort: false })
+	relevance: Array<number>;
 }
 /********************************** END **************************************/
 
@@ -67,6 +70,15 @@ export const MatrixSchema: TigrisIndexSchema<Matrix> = {
 					},
 				},
 			},
+		},
+	},
+	relevance: {
+		type: TigrisDataTypes.ARRAY,
+		searchIndex: true,
+		sort: false,
+		dimensions: 4,
+		items: {
+			type: TigrisDataTypes.NUMBER,
 		},
 	},
 };

--- a/src/__tests__/fixtures/schema/vacationRentals.ts
+++ b/src/__tests__/fixtures/schema/vacationRentals.ts
@@ -84,6 +84,9 @@ export class VacationRentals {
 
 	@Field(TigrisDataTypes.UUID, { default: GeneratedField.UUID })
 	referralId: string;
+
+	@Field({ dimensions: 3, default: [1.0, 1.0, 1.0] })
+	relevance: number[];
 }
 /********************************** END **************************************/
 
@@ -199,5 +202,13 @@ export const VacationsRentalSchema: TigrisSchema<VacationRentals> = {
 	referralId: {
 		type: TigrisDataTypes.UUID,
 		default: GeneratedField.UUID,
+	},
+	relevance: {
+		type: TigrisDataTypes.ARRAY,
+		dimensions: 3,
+		default: [1.0, 1.0, 1.0],
+		items: {
+			type: TigrisDataTypes.NUMBER,
+		},
 	},
 };

--- a/src/__tests__/search/schema.spec.ts
+++ b/src/__tests__/search/schema.spec.ts
@@ -4,6 +4,10 @@ import { Utility } from "../../utility";
 import { readJSONFileAsObj } from "../utils";
 import { DecoratedSchemaProcessor, IndexSchema } from "../../schema/decorated-schema-processor";
 import { MATRICES_INDEX_NAME, Matrix, MatrixSchema } from "../fixtures/schema/search/matrices";
+import { TigrisCollection } from "../../decorators/tigris-collection";
+import { Field } from "../../decorators/tigris-field";
+import { TigrisDataTypes } from "../../types";
+import { IncorrectVectorDefError } from "../../error";
 
 type SchemaTestCase<T extends TigrisIndexType> = {
 	schemaClass: T;
@@ -40,4 +44,19 @@ describe.each(schemas)("Schema conversion for: '$name'", (tc) => {
 			readJSONFileAsObj("src/__tests__/fixtures/json-schema/search/" + tc.expectedJSON)
 		);
 	});
+});
+
+test("throws error when Vector fields have incorrect type", () => {
+	let caught;
+
+	try {
+		@TigrisCollection("test_studio")
+		class Studio {
+			@Field({ dimensions: 3, elements: TigrisDataTypes.STRING })
+			actors: Array<string>;
+		}
+	} catch (e) {
+		caught = e;
+	}
+	expect(caught).toBeInstanceOf(IncorrectVectorDefError);
 });

--- a/src/__tests__/search/search.types.spec.ts
+++ b/src/__tests__/search/search.types.spec.ts
@@ -173,15 +173,19 @@ describe("SearchResponse parsing", () => {
 			const parsed: TextMatchInfo = TextMatchInfo.from(input);
 			expect(parsed.fields).toStrictEqual([]);
 			expect(parsed.score).toBe("");
+			expect(parsed.vectorDistance).toBeUndefined();
 		});
 		it("generates match field from input", () => {
 			const input: ProtoMatch = new ProtoMatch();
 			input.setScore("456");
 			input.addFields(new ProtoMatchField().setName("person"));
 			input.addFields(new ProtoMatchField().setName("user"));
+			input.setVectorDistance(0.24);
+
 			const parsed: TextMatchInfo = TextMatchInfo.from(input);
 			expect(parsed.fields).toEqual(expect.arrayContaining(["person", "user"]));
 			expect(parsed.score).toBe("456");
+			expect(parsed.vectorDistance).toBe(0.24);
 		});
 	});
 });

--- a/src/__tests__/tigris.schema.spec.ts
+++ b/src/__tests__/tigris.schema.spec.ts
@@ -1,5 +1,5 @@
 import { CollectionSchema, DecoratedSchemaProcessor } from "../schema/decorated-schema-processor";
-import { TigrisCollectionType, TigrisSchema } from "../types";
+import { TigrisCollectionType, TigrisDataTypes, TigrisSchema } from "../types";
 import { User, USERS_COLLECTION_NAME, UserSchema } from "./fixtures/schema/users";
 import {
 	RENTALS_COLLECTION_NAME,
@@ -7,7 +7,7 @@ import {
 	VacationsRentalSchema,
 } from "./fixtures/schema/vacationRentals";
 import { Field } from "../decorators/tigris-field";
-import { IncompleteArrayTypeDefError } from "../error";
+import { IncompleteArrayTypeDefError, IncorrectVectorDefError } from "../error";
 import { TigrisCollection } from "../decorators/tigris-collection";
 import { Utility } from "../utility";
 import { Order, ORDERS_COLLECTION_NAME, OrderSchema } from "./fixtures/schema/orders";
@@ -90,4 +90,19 @@ test("throws error when Arrays are not properly decorated", () => {
 		caught = e;
 	}
 	expect(caught).toBeInstanceOf(IncompleteArrayTypeDefError);
+});
+
+test("throws error when Vector fields have incorrect type", () => {
+	let caught;
+
+	try {
+		@TigrisCollection("test_studio")
+		class Studio {
+			@Field({ dimensions: 3, elements: TigrisDataTypes.STRING })
+			actors: Array<string>;
+		}
+	} catch (e) {
+		caught = e;
+	}
+	expect(caught).toBeInstanceOf(IncorrectVectorDefError);
 });

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -98,6 +98,7 @@ describe("utility tests", () => {
 			expect(request.getSearchFieldsList()).toEqual([]);
 			expect(request.getFilter()).toBe("");
 			expect(request.getFacet()).toBe("");
+			expect(request.getVector()).toBe("");
 			expect(request.getSort()).toBe("");
 			expect(request.getIncludeFieldsList()).toEqual([]);
 			expect(request.getExcludeFieldsList()).toEqual([]);
@@ -130,6 +131,19 @@ describe("utility tests", () => {
 
 			expect(request.getFacet()).toEqual(
 				Utility.stringToUint8Array('{"address.city":{"size":10,"type":"value"}}')
+			);
+		});
+
+		it("sets vector query", () => {
+			const query: SearchQuery<Student> = {
+				vectorQuery: {
+					field: "address.street",
+					vector: [0.4, -0.15, 0.9],
+				},
+			};
+			Utility.protoSearchRequestFromQuery(query, request);
+			expect(request.getVector()).toEqual(
+				Utility.stringToUint8Array('{"address.street":[0.4,-0.15,0.9]}')
 			);
 		});
 

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -137,8 +137,7 @@ describe("utility tests", () => {
 		it("sets vector query", () => {
 			const query: SearchQuery<Student> = {
 				vectorQuery: {
-					field: "address.street",
-					vector: [0.4, -0.15, 0.9],
+					"address.street": [0.4, -0.15, 0.9],
 				},
 			};
 			Utility.protoSearchRequestFromQuery(query, request);

--- a/src/error.ts
+++ b/src/error.ts
@@ -71,6 +71,16 @@ export class IncompleteArrayTypeDefError extends TigrisError {
 	}
 }
 
+export class IncorrectVectorDefError extends TigrisError {
+	constructor(object: Object, propertyName: string) {
+		super(`'${propertyName}' in '${object.constructor.name}' defines "dimensions" field option identifying it as a Vector data type.
+		The primitive data type for Vector can only be a 'number[]'`);
+	}
+	override get name(): string {
+		return "IncorrectVectorDefError";
+	}
+}
+
 export class IncompletePrimaryKeyDefError extends TigrisError {
 	constructor(object: Object, propertyName: string) {
 		super(`Missing "PrimaryKeyOptions" for '${object.constructor.name}#${propertyName}'`);

--- a/src/schema/decorated-schema-processor.ts
+++ b/src/schema/decorated-schema-processor.ts
@@ -198,6 +198,11 @@ const schemaOptions: SchemaFieldOptions[] = [
 		doesNotApplyTo: new Set([TigrisDataTypes.OBJECT]),
 		doesNotApplyToParent: new Set([TigrisDataTypes.ARRAY]),
 	},
+	{
+		attrName: "dimensions",
+		doesNotApplyTo: new Set([TigrisDataTypes.OBJECT, TigrisDataTypes.NUMBER]),
+		doesNotApplyToParent: new Set([TigrisDataTypes.ARRAY]),
+	},
 ];
 
 // searchIndex, sort and facet tags cannot be defined on top level object

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -113,11 +113,8 @@ export type Collation = {
  */
 export type VectorQuery = {
 	/**
-	 * Document field to query against. The field must be of 'Vector' type.
+	 * Document field to query against and the vector value to find nearest neighbors.
+	 * The field must be of 'Vector' type.
 	 */
-	field: string;
-	/**
-	 * Get nearest neighbors of this array of floating point numbers
-	 */
-	vector: Array<number>;
+	[key: string]: Array<number>;
 };

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -39,7 +39,6 @@ export interface SearchQuery<T extends TigrisCollectionType | TigrisIndexType> {
 	 * Maximum number of search hits (matched documents) to fetch per page
 	 */
 	hitsPerPage?: number;
-
 	/**
 	 * Other parameters for search query
 	 */
@@ -103,4 +102,10 @@ export enum Case {
  */
 export type Collation = {
 	case: Case;
+};
+
+export type Vector = {
+	field: string;
+	value: Array<number>;
+	size: number;
 };

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -24,6 +24,10 @@ export interface SearchQuery<T extends TigrisCollectionType | TigrisIndexType> {
 	 */
 	facets?: FacetFieldsQuery;
 	/**
+	 * Perform a nearest neighbor search to find closest documents
+	 */
+	vectorQuery?: VectorQuery;
+	/**
 	 * Sort the search results in indicated order
 	 */
 	sort?: SortOrder;
@@ -104,8 +108,16 @@ export type Collation = {
 	case: Case;
 };
 
-export type Vector = {
+/**
+ * A VectorQuery allows you to perform nearest neighbor search.
+ */
+export type VectorQuery = {
+	/**
+	 * Document field to query against. The field must be of 'Vector' type.
+	 */
 	field: string;
-	value: Array<number>;
-	size: number;
+	/**
+	 * Get nearest neighbors of this array of floating point numbers
+	 */
+	vector: Array<number>;
 };

--- a/src/search/result.ts
+++ b/src/search/result.ts
@@ -146,15 +146,19 @@ export class DocMeta {
 export class TextMatchInfo {
 	readonly fields: ReadonlyArray<string>;
 	readonly score: string;
+	readonly vectorDistance?: number;
 
-	constructor(fields: ReadonlyArray<string>, score: string) {
+	constructor(fields: ReadonlyArray<string>, score: string, vectorDistance?: number) {
 		this.fields = fields;
 		this.score = score;
+		if (vectorDistance) {
+			this.vectorDistance = vectorDistance;
+		}
 	}
 
 	static from(resp: ProtoMatch): TextMatchInfo {
 		const matchFields: Array<string> = resp.getFieldsList().map((f) => f.getName());
-		return new TextMatchInfo(matchFields, resp.getScore());
+		return new TextMatchInfo(matchFields, resp.getScore(), resp.getVectorDistance());
 	}
 }
 

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -13,6 +13,7 @@ export type SearchFieldOptions = {
 	searchIndex?: boolean;
 	sort?: boolean;
 	facet?: boolean;
+	dimensions?: number;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/types.ts
+++ b/src/types.ts
@@ -626,6 +626,10 @@ export type CollectionFieldOptions = {
 	 * Let DB generate values for `Date` type of fields
 	 */
 	timestamp?: AutoTimestamp;
+	/**
+	 * Dimensions for a vector field
+	 */
+	dimensions?: number;
 };
 
 export type TigrisSchema<T extends TigrisCollectionType> = {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -557,10 +557,7 @@ export const Utility = {
 		if (typeof q === "undefined") {
 			return "";
 		}
-		const queryObj = {
-			[q.field]: q.vector,
-		};
-		return this.objToJsonString(queryObj);
+		return this.objToJsonString(q);
 	},
 
 	_sortOrderingToString(ordering: SortOrder): string {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -34,6 +34,7 @@ import {
 	FacetQueryOptions,
 	MATCH_ALL_QUERY_STRING,
 	SearchQuery,
+	VectorQuery,
 } from "./search";
 import { TigrisIndexSchema } from "./search";
 import { SearchIndexRequest as ProtoSearchIndexRequest } from "./proto/server/v1/search_pb";
@@ -552,6 +553,16 @@ export const Utility = {
 		}
 	},
 
+	_vectorQueryToString(q: VectorQuery): string {
+		if (typeof q === "undefined") {
+			return "";
+		}
+		const queryObj = {
+			[q.field]: q.vector,
+		};
+		return this.objToJsonString(queryObj);
+	},
+
 	_sortOrderingToString(ordering: SortOrder): string {
 		if (typeof ordering === "undefined") {
 			return "[]";
@@ -584,6 +595,12 @@ export const Utility = {
 
 		if (query.facets !== undefined) {
 			searchRequest.setFacet(Utility.stringToUint8Array(Utility.facetQueryToString(query.facets)));
+		}
+
+		if (query.vectorQuery !== undefined) {
+			searchRequest.setVector(
+				Utility.stringToUint8Array(Utility._vectorQueryToString(query.vectorQuery))
+			);
 		}
 
 		if (query.sort !== undefined) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -464,12 +464,17 @@ export const Utility = {
 	): object {
 		const arrayBlock = {};
 		arrayBlock["type"] = "array";
-		arrayBlock["items"] = {};
-		arrayBlock["items"] = this._getSchemaProperties(
-			{ _$arrayItemPlaceholder: arraySchema["items"] },
-			pkeyMap,
-			keyMap
-		)["_$arrayItemPlaceholder"];
+		if (typeof arraySchema === "object" && "dimensions" in arraySchema) {
+			arrayBlock["dimensions"] = arraySchema["dimensions"];
+			arrayBlock["format"] = "vector";
+		} else {
+			arrayBlock["items"] = {};
+			arrayBlock["items"] = this._getSchemaProperties(
+				{ _$arrayItemPlaceholder: arraySchema["items"] },
+				pkeyMap,
+				keyMap
+			)["_$arrayItemPlaceholder"];
+		}
 		return arrayBlock;
 	},
 


### PR DESCRIPTION
## Describe your changes
- Introducing ability to define a vector type of field in a search index schema:
```ts
@SearchField({ dimensions: 4, sort: false })
relevance: Array<number>;
```
or a collection schema
```ts
@Field({ dimensions: 3, default: [1.0, 1.0, 1.0] })
relevance: number[];
```

which gets serialized to:
```json
"relevance": {
	"type": "array",
	"dimensions": 4,
	"format": "vector",
	"searchIndex": true,
	"sort": false
}
```
and
```json
"relevance": {
	"type": "array",
	"dimensions": 3,
	"format": "vector",
	"default": [1.0, 1.0, 1.0]
}
```

- Also, lets user query against these vector fields:
```ts
const query: SearchQuery<Movies> = {
	vectorQuery: {
		"relevance": [0.4, -0.15, 0.9],
	},
};
```

## How best to test these changes
- Unit tests

## Issue ticket number and link
closes #288 