### PR TITLE
Fix a bug with collection schema

### DIFF
--- a/src/__tests__/fixtures/json-schema/movies.json
+++ b/src/__tests__/fixtures/json-schema/movies.json
@@ -7,7 +7,8 @@
 			"type": "string"
 		},
 		"title": {
-			"type": "string"
+			"type": "string",
+			"searchIndex": true
 		},
 		"year": {
 			"type": "integer",
@@ -33,7 +34,9 @@
 			"type": "array",
 			"items": {
 				"type": "string"
-			}
+			},
+			"searchIndex": true,
+			"facet": true
 		},
 		"productionHouse": {
 			"type": "object",

--- a/src/__tests__/fixtures/schema/movies.ts
+++ b/src/__tests__/fixtures/schema/movies.ts
@@ -2,6 +2,7 @@ import { TigrisCollection } from "../../../decorators/tigris-collection";
 import { PrimaryKey } from "../../../decorators/tigris-primary-key";
 import { TigrisCollectionType, TigrisDataTypes, TigrisSchema } from "../../../types";
 import { Field } from "../../../decorators/tigris-field";
+import { SearchField } from "../../../decorators/tigris-search-field";
 
 /******************************************************************************
  * `Movie` class demonstrates a Tigris collection schema generated using
@@ -34,6 +35,7 @@ export class Movie {
 	@PrimaryKey(TigrisDataTypes.STRING, { order: 1 })
 	movieId: string;
 
+	@SearchField(TigrisDataTypes.STRING)
 	@Field(TigrisDataTypes.STRING)
 	title: string;
 
@@ -43,6 +45,7 @@ export class Movie {
 	@Field(TigrisDataTypes.ARRAY, { elements: Actor })
 	actors: Array<Actor>;
 
+	@SearchField(TigrisDataTypes.ARRAY, { elements: TigrisDataTypes.STRING, facet: true })
 	@Field(TigrisDataTypes.ARRAY, { elements: TigrisDataTypes.STRING })
 	genres: Array<string>;
 
@@ -68,6 +71,7 @@ export const MovieSchema: TigrisSchema<Movie> = {
 	},
 	title: {
 		type: TigrisDataTypes.STRING,
+		searchIndex: true,
 	},
 	year: {
 		type: TigrisDataTypes.INT32,
@@ -92,6 +96,8 @@ export const MovieSchema: TigrisSchema<Movie> = {
 		items: {
 			type: TigrisDataTypes.STRING,
 		},
+		searchIndex: true,
+		facet: true,
 	},
 	productionHouse: {
 		type: {

--- a/src/schema/decorated-schema-processor.ts
+++ b/src/schema/decorated-schema-processor.ts
@@ -176,11 +176,14 @@ export class DecoratedSchemaProcessor {
 
 		const fields = [];
 
+		// create a lookup for search fields
 		const searchFieldsLookup = [];
 		for (const field of searchFields) {
 			searchFieldsLookup[field.name] = field;
 		}
 
+		// process the collection fields
+		const visitedFields = new Set();
 		const collectionFields = this.storage.getCollectionFieldsByTarget(from);
 		for (const cf of collectionFields) {
 			let fieldOption = cf.schemaFieldOptions;
@@ -195,6 +198,15 @@ export class DecoratedSchemaProcessor {
 				...cf,
 				schemaFieldOptions: fieldOption,
 			});
+
+			visitedFields.add(cf.name);
+		}
+
+		// process the additional fields that are tagged as search fields
+		for (const sf of searchFields) {
+			if (!visitedFields.has(sf.name)) {
+				fields.push(sf);
+			}
 		}
 
 		return fields;


### PR DESCRIPTION
Fix a bug where for a collection schema, the collection field and schema field options were not merged properly.

If there was a field defined as follows:

```
@SearchField(TigrisDataTypes.ARRAY, { elements: TigrisDataTypes.STRING, facet: true })
@Field(TigrisDataTypes.ARRAY, { elements: TigrisDataTypes.STRING })
	genres: Array<string>;
```

The field annotation was overwriting the SearchField annotation.

Now with this change, we merge the options in the two annotations.

## Describe your changes

If a field has a SearchField annotation and a Field annotation, merge the field options.

## How best to test these changes

Unit tests

## Issue ticket number and link
