### PR TITLE
feat: dot notation for filters 

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -30,7 +30,6 @@ const EXPECTED_EXPORTS = [
 	"DocStatus",
 	"DropCollectionResponse",
 	"FacetCount",
-	"FacetQueryFieldType",
 	"FacetStats",
 	"Field",
 	"FindQueryOptions",

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -251,7 +251,10 @@ describe("filters tests", () => {
 					},
 				},
 				{
-					"address.city": "Paris",
+					// Selector filter on nested field as an object. Alternate: "address.city": "Paris"
+					address: {
+						city: "Paris",
+					},
 				},
 			],
 		};
@@ -261,6 +264,7 @@ describe("filters tests", () => {
 				{
 					op: SelectorFilterOperator.GTE,
 					fields: {
+						// filter on nested field as dot notation
 						"address.zipcode": 1200,
 					},
 				},

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -142,9 +142,7 @@ describe("filters tests", () => {
 				id: BigInt(1),
 				name: "alice",
 				balance: 12.34,
-				address: {
-					city: "San Francisco",
-				},
+				"address.city": "San Francisco",
 			},
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe(
@@ -166,9 +164,7 @@ describe("filters tests", () => {
 		const tigrisFilter: SelectorFilter<Student> = {
 			op: SelectorFilterOperator.LTE,
 			fields: {
-				address: {
-					zipcode: 10,
-				},
+				"address.zipcode": 10,
 			},
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"address.zipcode":{"$lte":10}}');
@@ -255,9 +251,7 @@ describe("filters tests", () => {
 					},
 				},
 				{
-					address: {
-						city: "Paris",
-					},
+					"address.city": "Paris",
 				},
 			],
 		};
@@ -267,9 +261,7 @@ describe("filters tests", () => {
 				{
 					op: SelectorFilterOperator.GTE,
 					fields: {
-						address: {
-							zipcode: 1200,
-						},
+						"address.zipcode": 1200,
 					},
 				},
 				{

--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -508,7 +508,7 @@ describe("rpc tests", () => {
 				const query: SearchQuery<IBook> = {
 					q: "philosophy",
 					facets: {
-						tags: Utility.createFacetQueryOptions(),
+						tags: Utility.defaultFacetingOptions(),
 					},
 				};
 
@@ -530,7 +530,7 @@ describe("rpc tests", () => {
 				const query: SearchQuery<IBook> = {
 					q: "philosophy",
 					facets: {
-						tags: Utility.createFacetQueryOptions(),
+						tags: Utility.defaultFacetingOptions(),
 					},
 				};
 				let bookCounter = 0;

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -4,7 +4,6 @@ import {
 	FacetFieldOptions,
 	FacetFields,
 	FacetFieldsQuery,
-	FacetQueryFieldType,
 	MATCH_ALL_QUERY_STRING,
 	SearchQuery,
 	SearchQueryOptions,
@@ -27,17 +26,17 @@ describe("utility tests", () => {
 	});
 
 	it("generates default facet query options", () => {
-		const generatedOptions = Utility.createFacetQueryOptions();
+		const generatedOptions = Utility.defaultFacetingOptions();
 		expect(generatedOptions.size).toBe(10);
-		expect(generatedOptions.type).toBe(FacetQueryFieldType.VALUE);
+		expect(generatedOptions.type).toBe("value");
 	});
 
 	it("backfills missing facet query options", () => {
-		const generatedOptions = Utility.createFacetQueryOptions({
+		const generatedOptions = Utility.defaultFacetingOptions({
 			size: 55,
 		});
 		expect(generatedOptions.size).toBe(55);
-		expect(generatedOptions.type).toBe(FacetQueryFieldType.VALUE);
+		expect(generatedOptions.type).toBe("value");
 	});
 
 	it("serializes FacetFields to string", () => {
@@ -50,8 +49,8 @@ describe("utility tests", () => {
 
 	it("serializes FacetFieldOptions to string", () => {
 		const fields: FacetFieldOptions = {
-			field_1: Utility.createFacetQueryOptions(),
-			field_2: { size: 10, type: FacetQueryFieldType.VALUE },
+			field_1: Utility.defaultFacetingOptions(),
+			field_2: { size: 10 },
 		};
 		const serialized: string = Utility.facetQueryToString(fields);
 		expect(serialized).toBe(
@@ -62,8 +61,8 @@ describe("utility tests", () => {
 	it("equivalent serialization of FacetFieldsQuery", () => {
 		const facetFields: FacetFieldsQuery = ["field_1", "field_2"];
 		const fieldOptions: FacetFieldsQuery = {
-			field_1: Utility.createFacetQueryOptions(),
-			field_2: { size: 10, type: FacetQueryFieldType.VALUE },
+			field_1: Utility.defaultFacetingOptions(),
+			field_2: { size: 10, type: "value" },
 		};
 		const serializedFields = Utility.facetQueryToString(facetFields);
 		expect(serializedFields).toBe(Utility.facetQueryToString(fieldOptions));

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -87,12 +87,8 @@ export type FacetQueryOptions = {
 	/**
 	 * Type of facets to build
 	 */
-	type: FacetQueryFieldType;
+	type?: "value";
 };
-
-export enum FacetQueryFieldType {
-	VALUE = "value",
-}
 
 export enum Case {
 	/**

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -75,13 +75,12 @@ export type FacetFields = Array<string>;
 
 /**
  * Information to build facets in search results
- * Use `Utility.createFacetQueryOptions()` to generate using defaults
  *
- * @see {@link Utility.createFacetQueryOptions}
  */
 export type FacetQueryOptions = {
 	/**
 	 * Maximum number of facets to include in results
+	 * default - 10
 	 */
 	size: number;
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -683,6 +683,7 @@ type Paths<T, P extends string = ""> = {
 /**
  * This type helps to infer the type of the path that Paths (above) has generated.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type PathType<T, P extends string> = P extends keyof T
 	? T[P]
 	: P extends `${infer L}.${infer R}`
@@ -691,8 +692,9 @@ type PathType<T, P extends string> = P extends keyof T
 		: never
 	: never;
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Selector<T> = Partial<{
-	[K in Paths<T>]: Partial<PathType<T, K & string>>;
+	[K in string]: unknown;
 }>;
 
 export type SelectorFilter<T> = Partial<{

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -30,7 +30,6 @@ import {
 import { TigrisClientConfig } from "./tigris";
 import {
 	FacetFieldsQuery,
-	FacetQueryFieldType,
 	FacetQueryOptions,
 	MATCH_ALL_QUERY_STRING,
 	SearchQuery,
@@ -536,21 +535,23 @@ export const Utility = {
 		return this.jsonStringToObj(Buffer.from(b64String, "base64").toString("utf8"), config);
 	},
 
-	createFacetQueryOptions(options?: Partial<FacetQueryOptions>): FacetQueryOptions {
-		const defaults = { size: 10, type: FacetQueryFieldType.VALUE };
+	defaultFacetingOptions(options?: Partial<FacetQueryOptions>): FacetQueryOptions {
+		const defaults: FacetQueryOptions = { size: 10, type: "value" };
 		return { ...defaults, ...options };
 	},
 
 	facetQueryToString(facets: FacetFieldsQuery): string {
+		const optionsMap = {};
 		if (Array.isArray(facets)) {
-			const optionsMap = {};
 			for (const f of facets) {
-				optionsMap[f] = this.createFacetQueryOptions();
+				optionsMap[f] = this.defaultFacetingOptions();
 			}
-			return this.objToJsonString(optionsMap);
-		} else {
-			return this.objToJsonString(facets);
+		} else if (typeof facets === "object") {
+			for (const f in facets) {
+				optionsMap[f] = this.defaultFacetingOptions(facets[f]);
+			}
 		}
+		return this.objToJsonString(optionsMap);
 	},
 
 	_vectorQueryToString(q: VectorQuery): string {


### PR DESCRIPTION
## Describe your changes
- `type` is optional for **FacetQueryOptions**
- Filter specification for nested fields supports both - dot notation and nested objects

## How best to test these changes
- Unit tests


BREAKING CHANGE: Filters are no more generics
