### PR TITLE
Add support for id annotation on search index

### DIFF
--- a/src/__tests__/fixtures/json-schema/search/orders.json
+++ b/src/__tests__/fixtures/json-schema/search/orders.json
@@ -11,7 +11,8 @@
 		"customerId": {
 			"type": "string",
 			"searchIndex": true,
-			"facet": false
+			"facet": false,
+			"id": true
 		},
 		"products": {
 			"type": "array",

--- a/src/__tests__/fixtures/schema/search/matrices.ts
+++ b/src/__tests__/fixtures/schema/search/matrices.ts
@@ -19,7 +19,7 @@ export class Cell {
 	@SearchField()
 	y: number;
 
-	@SearchField()
+	@SearchField({ id: true })
 	value: string;
 }
 

--- a/src/__tests__/fixtures/schema/search/orders.ts
+++ b/src/__tests__/fixtures/schema/search/orders.ts
@@ -48,7 +48,7 @@ export class Order {
 	@SearchField(TigrisDataTypes.UUID, { sort: true })
 	orderId: string;
 
-	@SearchField({ facet: false })
+	@SearchField({ facet: false, id: true })
 	customerId: string;
 
 	@SearchField({ elements: Product })
@@ -74,6 +74,7 @@ export const OrderSchema: TigrisIndexSchema<Order> = {
 		type: TigrisDataTypes.STRING,
 		searchIndex: true,
 		facet: false,
+		id: true,
 	},
 	products: {
 		type: TigrisDataTypes.ARRAY,

--- a/src/schema/decorated-schema-processor.ts
+++ b/src/schema/decorated-schema-processor.ts
@@ -250,6 +250,20 @@ const schemaOptions: SchemaFieldOptions[] = [
 		doesNotApplyTo: new Set([TigrisDataTypes.OBJECT, TigrisDataTypes.NUMBER]),
 		doesNotApplyToParent: new Set([TigrisDataTypes.ARRAY]),
 	},
+	{
+		attrName: "id",
+		doesNotApplyTo: new Set([
+			TigrisDataTypes.OBJECT,
+			TigrisDataTypes.ARRAY,
+			TigrisDataTypes.NUMBER,
+			TigrisDataTypes.BOOLEAN,
+			TigrisDataTypes.NUMBER_BIGINT,
+			TigrisDataTypes.INT64,
+			TigrisDataTypes.INT32,
+			TigrisDataTypes.DATE_TIME,
+		]),
+		doesNotApplyToParent: new Set([TigrisDataTypes.ARRAY]),
+	},
 ];
 
 // searchIndex, sort and facet tags cannot be defined on top level object

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -14,6 +14,7 @@ export type SearchFieldOptions = {
 	sort?: boolean;
 	facet?: boolean;
 	dimensions?: number;
+	id?: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -400,6 +400,9 @@ export const Utility = {
 			if ("facet" in schema[property]) {
 				thisProperty["facet"] = schema[property]["facet"];
 			}
+			if ("id" in schema[property]) {
+				thisProperty["id"] = schema[property]["id"];
+			}
 
 			// 'timestamp' values for schema fields
 			if ("timestamp" in schema[property]) {


### PR DESCRIPTION
## Describe your changes

A string field can be annotated in a search index and that field value will be used as the document ID

## How best to test these changes

Unit tests

## Issue ticket number and link
