### PR TITLE
fix: set createdAt timestamp field value on collection insert if not exists

### DIFF
--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -147,6 +147,25 @@ describe("rpc tests", () => {
 		});
 		insertionPromise.then((insertedBook) => {
 			expect(insertedBook.id).toBe(1);
+			expect(insertedBook.createdAt).toBeDefined();
+		});
+		return insertionPromise;
+	});
+
+	it("insert_with_createdAt_value", async () => {
+		const tigris = new Tigris({ ...testConfig, projectName: "db3" });
+		const db1 = tigris.getDatabase();
+		const book: IBook = {
+			author: "author name",
+			id: 0,
+			tags: ["science"],
+			title: "science book",
+			createdAt: new Date(),
+		}
+		const insertionPromise = db1.getCollection<IBook>("books").insertOne(book);
+		insertionPromise.then((insertedBook) => {
+			expect(insertedBook.id).toBe(1);
+			expect(insertedBook.createdAt).toEqual(book.createdAt);
 		});
 		return insertionPromise;
 	});
@@ -915,6 +934,8 @@ export class IBook implements TigrisCollectionType {
 	author: string;
 	@Field({ elements: TigrisDataTypes.STRING })
 	tags?: string[];
+	@Field(TigrisDataTypes.DATE_TIME, { timestamp: "createdAt" })
+  	createdAt?: Date;
 }
 
 export interface IBook1 extends TigrisCollectionType {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -101,7 +101,6 @@ export class Collection<T extends TigrisCollectionType> implements ICollection {
 							clonedDocs = this.setCreatedAtForDocsIfNotExists(clonedDocs, 
 								new Date(response.getMetadata()?.getCreatedAt()?.getSeconds() * 1000));
 						}
-						console.log('CLONE :: ', clonedDocs);
 						resolve(clonedDocs);
 					}
 				}


### PR DESCRIPTION
## Describe your changes
- Added a check,  if the gRPC insert response does not contain the createdAt timestamp field value then add those respective field values from the response metadata or else ignore.
- Identified createdAt timestamp fields with the help of DecoratorMetaStorage for the specific collection.

/claim #245 

## How best to test these changes
- Added the individual test cases for this scenario.

## Issue ticket number and link
Fixes #245 
