### PR TITLE
refactor: primaryKeyOptions as optional if there is only one primary key for collection

### DIFF
--- a/src/__tests__/fixtures/json-schema/students.json
+++ b/src/__tests__/fixtures/json-schema/students.json
@@ -1,0 +1,27 @@
+{
+	"title": "students",
+	"additionalProperties": false,
+	"type": "object",
+	"properties": {
+		"id": {
+			"type": "integer",
+			"format": "int64",
+			"autoGenerate": true
+		},
+		"email": {
+			"type": "string"
+		},
+		"firstName": {
+			"type": "string"
+		},
+		"lastName": {
+			"type": "string"
+		},
+		"createdAt": {
+			"type": "string",
+			"format": "date-time",
+			"createdAt": true
+		}
+	},
+	"primary_key": ["id", "email"]
+}

--- a/src/__tests__/fixtures/schema/movies.ts
+++ b/src/__tests__/fixtures/schema/movies.ts
@@ -32,7 +32,8 @@ export class Actor {
 
 @TigrisCollection(MOVIES_COLLECTION_NAME)
 export class Movie {
-	@PrimaryKey(TigrisDataTypes.STRING, { order: 1 })
+	// Ignored order in primary key options as it was only primary key.
+	@PrimaryKey(TigrisDataTypes.STRING)
 	movieId: string;
 
 	@SearchField(TigrisDataTypes.STRING)

--- a/src/__tests__/fixtures/schema/student.ts
+++ b/src/__tests__/fixtures/schema/student.ts
@@ -1,0 +1,93 @@
+import { TigrisCollection } from "../../../decorators/tigris-collection";
+import { PrimaryKey } from "../../../decorators/tigris-primary-key";
+import { TigrisDataTypes, TigrisSchema } from "../../../types";
+import { Field } from "../../../decorators/tigris-field";
+
+/******************************************************************************
+ * `Student` class demonstrates a Tigris collection schema generated using
+ * decorators. Type of collection fields is inferred using Reflection APIs. This
+ * particular schema example:
+ * - infers the type of collection fields automatically using Reflection APIs
+ * - has multiple primary keys
+ *****************************************************************************/
+export const STUDENT_COLLECTION_NAME = "students";
+
+@TigrisCollection(STUDENT_COLLECTION_NAME)
+export class Student {
+	@PrimaryKey(TigrisDataTypes.INT64, { order: 1, autoGenerate: true })
+	id?: string;
+
+	@PrimaryKey(TigrisDataTypes.STRING, { order: 2 })
+	email: string;
+
+	@Field()
+	firstName!: string;
+
+	@Field()
+	lastName!: string;
+
+	@Field({ timestamp: "createdAt" })
+	createdAt?: Date;
+}
+
+/********************************** END **************************************/
+
+/******************************************************************************
+ * `InvalidStudent` class demonstrates a Tigris collection schema validation,
+ *  Schema is INVALID as it contains two primary keys but no order was specified
+ *  in decorator under PrimaryKeyOptions.
+ *****************************************************************************/
+export const INVALID_STUDENT_COLLECTION_NAME = "invalid_students";
+
+@TigrisCollection(INVALID_STUDENT_COLLECTION_NAME)
+export class InvalidStudent {
+	@PrimaryKey(TigrisDataTypes.INT64)
+	id?: string;
+
+	@PrimaryKey(TigrisDataTypes.STRING)
+	email: string;
+
+	@Field()
+	firstName!: string;
+
+	@Field()
+	lastName!: string;
+
+	@Field({ timestamp: "createdAt" })
+	createdAt?: Date;
+}
+
+/********************************** END **************************************/
+
+/**
+ * `TigrisSchema` representation of the `Student` collection class .
+ *
+ * NOTE: This is only an illustration; you don't have to write this definition,
+ * it will be auto generated.
+ */
+export const StudentSchema: TigrisSchema<Student> = {
+	id: {
+		type: TigrisDataTypes.INT64,
+		primary_key: {
+			order: 1,
+			autoGenerate: true,
+		},
+	},
+	email: {
+		type: TigrisDataTypes.STRING,
+		primary_key: {
+			order: 2,
+			autoGenerate: false,
+		},
+	},
+	firstName: {
+		type: TigrisDataTypes.STRING,
+	},
+	lastName: {
+		type: TigrisDataTypes.STRING,
+	},
+	createdAt: {
+		type: TigrisDataTypes.DATE_TIME,
+		timestamp: "createdAt",
+	},
+};

--- a/src/__tests__/tigris.schema.spec.ts
+++ b/src/__tests__/tigris.schema.spec.ts
@@ -7,13 +7,23 @@ import {
 	VacationsRentalSchema,
 } from "./fixtures/schema/vacationRentals";
 import { Field } from "../decorators/tigris-field";
-import { IncompleteArrayTypeDefError, IncorrectVectorDefError } from "../error";
+import {
+	IncompleteArrayTypeDefError,
+	IncompletePrimaryKeyOrderError,
+	IncorrectVectorDefError,
+} from "../error";
 import { TigrisCollection } from "../decorators/tigris-collection";
 import { Utility } from "../utility";
 import { Order, ORDERS_COLLECTION_NAME, OrderSchema } from "./fixtures/schema/orders";
 import { Movie, MOVIES_COLLECTION_NAME, MovieSchema } from "./fixtures/schema/movies";
 import { MATRICES_COLLECTION_NAME, Matrix, MatrixSchema } from "./fixtures/schema/matrices";
 import { readJSONFileAsObj } from "./utils";
+import {
+	InvalidStudent,
+	STUDENT_COLLECTION_NAME,
+	Student,
+	StudentSchema,
+} from "./fixtures/schema/student";
 
 type SchemaTestCase<T extends TigrisCollectionType> = {
 	schemaClass: T;
@@ -53,6 +63,12 @@ const schemas: Array<SchemaTestCase<any>> = [
 		name: RENTALS_COLLECTION_NAME,
 		expectedJson: "vacationRentals.json",
 	},
+	{
+		schemaClass: Student,
+		expectedSchema: StudentSchema,
+		name: STUDENT_COLLECTION_NAME,
+		expectedJson: "students.json",
+	},
 ];
 
 /*
@@ -75,6 +91,17 @@ describe.each(schemas)("Schema conversion for: '$name'", (tc) => {
 			readJSONFileAsObj("src/__tests__/fixtures/json-schema/" + tc.expectedJson)
 		);
 	});
+});
+
+test("throws error when Schema is invalid with more than one primary key but no orders specified", () => {
+	const processor = DecoratedSchemaProcessor.Instance;
+	let caught;
+	try {
+		processor.processCollection(InvalidStudent);
+	} catch (err) {
+		caught = err;
+	}
+	expect(caught).toBeInstanceOf(IncompletePrimaryKeyOrderError);
 });
 
 test("throws error when Arrays are not properly decorated", () => {

--- a/src/decorators/tigris-primary-key.ts
+++ b/src/decorators/tigris-primary-key.ts
@@ -1,10 +1,6 @@
 import "reflect-metadata";
 import { PrimaryKeyOptions, TigrisDataTypes } from "../types";
-import {
-	CannotInferFieldTypeError,
-	IncompletePrimaryKeyDefError,
-	ReflectionNotEnabled,
-} from "../error";
+import { CannotInferFieldTypeError, ReflectionNotEnabled } from "../error";
 import { getDecoratorMetaStorage } from "../globals";
 import { PrimaryKeyMetadata } from "./metadata/primary-key-metadata";
 import { Log } from "../utils/logger";
@@ -16,7 +12,7 @@ import { Log } from "../utils/logger";
  *
  * @param options - Additional properties
  */
-export function PrimaryKey(options: PrimaryKeyOptions): PropertyDecorator;
+export function PrimaryKey(options?: PrimaryKeyOptions): PropertyDecorator;
 /**
  * PrimaryKey decorator is used to mark a class property as Primary Key in a collection.
  *
@@ -25,7 +21,7 @@ export function PrimaryKey(options: PrimaryKeyOptions): PropertyDecorator;
  * @param type - Schema field's data type
  * @param options - Additional properties
  */
-export function PrimaryKey(type: TigrisDataTypes, options: PrimaryKeyOptions): PropertyDecorator;
+export function PrimaryKey(type: TigrisDataTypes, options?: PrimaryKeyOptions): PropertyDecorator;
 
 /**
  * PrimaryKey decorator is used to mark a class property as Primary Key in a collection.
@@ -42,11 +38,6 @@ export function PrimaryKey(
 			propertyType = typeOrOptions as TigrisDataTypes;
 		} else if (typeof typeOrOptions === "object") {
 			options = typeOrOptions as PrimaryKeyOptions;
-		}
-
-		// throw error if options are undefined
-		if (!options) {
-			throw new IncompletePrimaryKeyDefError(target, propertyName);
 		}
 
 		// infer type from reflection

--- a/src/error.ts
+++ b/src/error.ts
@@ -91,6 +91,18 @@ export class IncompletePrimaryKeyDefError extends TigrisError {
 	}
 }
 
+export class IncompletePrimaryKeyOrderError extends TigrisError {
+	constructor(name: string, collectionName: string) {
+		super(
+			`Missing 'order' value in "PrimaryKeyOptions" for variable '${name}' in ${collectionName} collection`
+		);
+	}
+
+	override get name(): string {
+		return "IncompletePrimaryKeyOrderError";
+	}
+}
+
 export class CollectionNotFoundError extends TigrisError {
 	constructor(name: string) {
 		super(`Collection not found : '${name}'`);


### PR DESCRIPTION
## Describe your changes
- Order in the primaryKeyOptions is not required when there is only one primary key in the collection.
- Order is required when there are multiple primary keys.

#242 
/claim #242

## How best to test these changes
- npm run test , Added individual test cases. 

## Issue ticket number and link
Fixes: #242 