### PR TITLE
chore: re-write Filter<T>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"@semantic-release/npm": "^9.0.1",
 				"@types/jest": "^28.1.8",
 				"@types/json-bigint": "^1.0.1",
+				"@types/node": "^18.15.11",
 				"@typescript-eslint/eslint-plugin": "^5.35.1",
 				"@typescript-eslint/parser": "^5.35.1",
 				"copyfiles": "^2.4.1",
@@ -1977,9 +1978,9 @@
 			"peer": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-			"integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw=="
+			"version": "18.15.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+			"integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.1",
@@ -13036,9 +13037,9 @@
 			"peer": true
 		},
 		"@types/node": {
-			"version": "18.7.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-			"integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw=="
+			"version": "18.15.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+			"integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -88,13 +88,14 @@
 		"@semantic-release/npm": "^9.0.1",
 		"@types/jest": "^28.1.8",
 		"@types/json-bigint": "^1.0.1",
+		"@types/node": "^18.15.11",
 		"@typescript-eslint/eslint-plugin": "^5.35.1",
 		"@typescript-eslint/parser": "^5.35.1",
-		"eslint-plugin-tsdoc": "0.2.17",
 		"copyfiles": "^2.4.1",
 		"eslint": "^8.22.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-functional": "^4.2.2",
+		"eslint-plugin-tsdoc": "0.2.17",
 		"eslint-plugin-unicorn": "^43.0.2",
 		"eslint-plugin-unused-imports": "^2.0.0",
 		"grpc_tools_node_protoc_ts": "^5.3.2",
@@ -109,11 +110,11 @@
 	},
 	"dependencies": {
 		"@grpc/grpc-js": "^1.6.10",
+		"app-root-path": "^3.1.0",
 		"chalk": "4.1.2",
 		"dotenv": "^16.0.3",
 		"google-protobuf": "^3.21.0",
 		"json-bigint": "github:sidorares/json-bigint",
-		"reflect-metadata": "^0.1.13",
-		"app-root-path": "^3.1.0"
+		"reflect-metadata": "^0.1.13"
 	}
 }

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -2,8 +2,7 @@ import {
 	LogicalFilter,
 	LogicalOperator,
 	Selector,
-	SelectorFilter,
-	SelectorFilterOperator,
+	SelectorOperator,
 	TigrisCollectionType,
 	TigrisDataTypes,
 } from "../types";
@@ -14,37 +13,36 @@ import { Field } from "../decorators/tigris-field";
 
 describe("filters tests", () => {
 	it("simpleSelectorFilterTest", () => {
-		const filterNothing: SelectorFilter<IUser> = {
-			op: SelectorFilterOperator.NONE,
-		};
+		const filterNothing: Selector<IUser> = {};
 		expect(Utility.filterToString(filterNothing)).toBe("{}");
+
 		const filter1: Selector<IUser> = {
-			name: "Alice",
+			name: {$eq: "Alice"},
 		};
 		expect(Utility.filterToString(filter1)).toBe('{"name":"Alice"}');
 
 		const filter2: Selector<IUser> = {
-			balance: 100,
+			balance: {$eq: 100},
 		};
 		expect(Utility.filterToString(filter2)).toBe('{"balance":100}');
 
 		const filter3: Selector<IUser1> = {
-			isActive: true,
+			isActive: {$eq: true},
 		};
 		expect(Utility.filterToString(filter3)).toBe('{"isActive":true}');
 	});
 
 	it("persists date string as it is", () => {
-		const dateFilter: SelectorFilter<IUser1> = {
-			op: SelectorFilterOperator.GT,
-			fields: {
-				createdAt: "1980-01-01T18:29:28.000Z",
-			},
+		const dateFilter: Selector<IUser1> = {
+		  $gt: {
+			createdAt: "1980-01-01T18:29:28.000Z",
+		  },
 		};
 		expect(Utility.filterToString(dateFilter)).toBe(
-			'{"createdAt":{"$gt":"1980-01-01T18:29:28.000Z"}}'
+		  '{"$gt":{"createdAt":"1980-01-01T18:29:28.000Z"}}'
 		);
 	});
+	  
 
 	it("serializes Date object to string", () => {
 		const dateFilter: SelectorFilter<IUser1> = {
@@ -60,8 +58,8 @@ describe("filters tests", () => {
 
 	it("simplerSelectorWithinLogicalFilterTest", () => {
 		const filter1: LogicalFilter<IUser> = {
-			op: LogicalOperator.AND,
-			selectorFilters: [
+			"$and",
+			selector: [
 				{
 					name: "Alice",
 				},

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -1,8 +1,6 @@
 import {
 	LogicalFilter,
-	LogicalOperator,
 	Selector,
-	SelectorOperator,
 	TigrisCollectionType,
 	TigrisDataTypes,
 } from "../types";
@@ -17,26 +15,24 @@ describe("filters tests", () => {
 		expect(Utility.filterToString(filterNothing)).toBe("{}");
 
 		const filter1: Selector<IUser> = {
-			name: {$eq: "Alice"},
+			name: {"$eq": "Alice"},
 		};
 		expect(Utility.filterToString(filter1)).toBe('{"name":"Alice"}');
 
 		const filter2: Selector<IUser> = {
-			balance: {$eq: 100},
+			balance: {"$eq": 100},
 		};
 		expect(Utility.filterToString(filter2)).toBe('{"balance":100}');
 
 		const filter3: Selector<IUser1> = {
-			isActive: {$eq: true},
+			isActive: {"$eq": true},
 		};
 		expect(Utility.filterToString(filter3)).toBe('{"isActive":true}');
 	});
 
 	it("persists date string as it is", () => {
 		const dateFilter: Selector<IUser1> = {
-		  $gt: {
-			createdAt: "1980-01-01T18:29:28.000Z",
-		  },
+			createdAt: {"$gt": "1980-01-01T18:29:28.000Z"},
 		};
 		expect(Utility.filterToString(dateFilter)).toBe(
 		  '{"$gt":{"createdAt":"1980-01-01T18:29:28.000Z"}}'
@@ -45,11 +41,8 @@ describe("filters tests", () => {
 	  
 
 	it("serializes Date object to string", () => {
-		const dateFilter: SelectorFilter<IUser1> = {
-			op: SelectorFilterOperator.LT,
-			fields: {
-				updatedAt: new Date("1980-01-01"),
-			},
+		const dateFilter: Selector<IUser1> = {
+			updatedAt: {"$lt": new Date("1980-01-01")}
 		};
 		expect(Utility.filterToString(dateFilter)).toBe(
 			'{"updatedAt":{"$lt":"1980-01-01T00:00:00.000Z"}}'
@@ -58,8 +51,7 @@ describe("filters tests", () => {
 
 	it("simplerSelectorWithinLogicalFilterTest", () => {
 		const filter1: LogicalFilter<IUser> = {
-			"$and",
-			selector: [
+			"$and": [
 				{
 					name: "Alice",
 				},
@@ -71,8 +63,7 @@ describe("filters tests", () => {
 		expect(Utility.filterToString(filter1)).toBe('{"$and":[{"name":"Alice"},{"balance":100}]}');
 
 		const filter2: LogicalFilter<IUser> = {
-			op: LogicalOperator.OR,
-			selectorFilters: [
+			"$or": [
 				{
 					name: "Alice",
 				},
@@ -85,63 +76,48 @@ describe("filters tests", () => {
 	});
 
 	it("basicSelectorFilterTest", () => {
-		const filter1: SelectorFilter<IUser> = {
-			op: SelectorFilterOperator.EQ,
-			fields: {
-				name: "Alice",
-			},
+		const filter1: Selector<IUser> = { 
+			name: "Alice",
 		};
 		expect(Utility.filterToString(filter1)).toBe('{"name":"Alice"}');
 
-		const filter2: SelectorFilter<IUser> = {
-			op: SelectorFilterOperator.EQ,
-			fields: {
-				id: BigInt(123),
-			},
+		const filter2: Selector<IUser> = {
+			id: BigInt(123),
 		};
 		expect(Utility.filterToString(filter2)).toBe('{"id":123}');
 
-		const filter3: SelectorFilter<IUser1> = {
-			op: SelectorFilterOperator.EQ,
-			fields: {
-				isActive: true,
-			},
+		const filter3: Selector<IUser1> = {
+			isActive: true,
 		};
 		expect(Utility.filterToString(filter3)).toBe('{"isActive":true}');
 	});
 
 	it("selectorFilter_1", () => {
-		const tigrisFilter: SelectorFilter<Student> = {
-			op: SelectorFilterOperator.EQ,
-			fields: {
+		const tigrisFilter: Selector<Student> = {
+	
 				id: BigInt(1),
 				name: "alice",
-			},
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"id":1,"name":"alice"}');
 	});
 
 	it("selectorFilter_2", () => {
-		const tigrisFilter: SelectorFilter<Student> = {
-			op: SelectorFilterOperator.EQ,
-			fields: {
+		const tigrisFilter: Selector<Student> = {
+			
 				id: BigInt(1),
 				name: "alice",
 				balance: 12.34,
-			},
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"id":1,"name":"alice","balance":12.34}');
 	});
 
 	it("selectorFilter_3", () => {
-		const tigrisFilter: SelectorFilter<Student> = {
-			op: SelectorFilterOperator.EQ,
-			fields: {
+		const tigrisFilter: Selector<Student> = {
+		
 				id: BigInt(1),
 				name: "alice",
 				balance: 12.34,
 				"address.city": "San Francisco",
-			},
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe(
 			'{"id":1,"name":"alice","balance":12.34,"address.city":"San Francisco"}'
@@ -149,66 +125,52 @@ describe("filters tests", () => {
 	});
 
 	it("less than Filter", () => {
-		const tigrisFilter: SelectorFilter<Student> = {
-			op: SelectorFilterOperator.LT,
-			fields: {
-				balance: 10,
-			},
+		const tigrisFilter: Selector<Student> = {
+			balance: {"$lt":10},
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"balance":{"$lt":10}}');
 	});
 
 	it("less than equals Filter", () => {
-		const tigrisFilter: SelectorFilter<Student> = {
-			op: SelectorFilterOperator.LTE,
-			fields: {
-				"address.zipcode": 10,
-			},
+		const tigrisFilter: Selector<Student> = {
+			"address.zipcode": {"$lte": 10} 
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"address.zipcode":{"$lte":10}}');
 	});
 
 	it("greater than Filter", () => {
-		const tigrisFilter: SelectorFilter<Student> = {
-			op: SelectorFilterOperator.GT,
-			fields: {
-				balance: 10,
-			},
+		const tigrisFilter: Selector<Student> = {
+		
+				balance: {"$gt": 10},
+			
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"balance":{"$gt":10}}');
 	});
 
 	it("greater than equals Filter", () => {
-		const tigrisFilter: SelectorFilter<Student> = {
-			op: SelectorFilterOperator.GTE,
-			fields: {
-				balance: 10,
-			},
+		const tigrisFilter: Selector<Student> = {
+			
+			
+				balance: {"$gt": 10},
+			
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"balance":{"$gte":10}}');
 	});
 
 	it("logicalFilterTest1", () => {
 		const logicalFilter: LogicalFilter<IUser> = {
-			op: LogicalOperator.OR,
-			selectorFilters: [
+			
+			"$or": [
 				{
-					op: SelectorFilterOperator.EQ,
-					fields: {
-						name: "alice",
-					},
+					
+					name: "alice",
+					
 				},
 				{
-					op: SelectorFilterOperator.EQ,
-					fields: {
-						name: "emma",
-					},
+					name: "emma",
 				},
 				{
-					op: SelectorFilterOperator.GT,
-					fields: {
-						balance: 300,
-					},
+					balance: {"$gt": 300},
 				},
 			],
 		};
@@ -219,19 +181,12 @@ describe("filters tests", () => {
 
 	it("logicalFilterTest2", () => {
 		const logicalFilter: LogicalFilter<IUser2> = {
-			op: LogicalOperator.AND,
-			selectorFilters: [
+			"$and": [
 				{
-					op: SelectorFilterOperator.EQ,
-					fields: {
-						name: "alice",
-					},
+					name: "alice",
 				},
 				{
-					op: SelectorFilterOperator.EQ,
-					fields: {
-						rank: 1,
-					},
+					rank: 1,
 				},
 			],
 		};
@@ -240,43 +195,30 @@ describe("filters tests", () => {
 
 	it("nestedLogicalFilter1", () => {
 		const logicalFilter1: LogicalFilter<Student> = {
-			op: LogicalOperator.AND,
-			selectorFilters: [
+			"$and": [
 				{
-					op: SelectorFilterOperator.EQ,
-					fields: {
-						name: "alice",
-					},
+					name: "alice",
 				},
 				{
 					// Selector filter on nested field as an object. Alternate: "address.city": "Paris"
-					address: {
-						city: "Paris",
-					},
+					"address.city": "Paris" 
 				},
 			],
 		};
 		const logicalFilter2: LogicalFilter<Student> = {
-			op: LogicalOperator.AND,
-			selectorFilters: [
-				{
-					op: SelectorFilterOperator.GTE,
-					fields: {
-						// filter on nested field as dot notation
-						"address.zipcode": 1200,
-					},
+			"$and": [
+				{	
+				  // filter on nested field as dot notation
+                  {"address.zipcode": {"$gte": 2000}}	
 				},
 				{
-					op: SelectorFilterOperator.LTE,
-					fields: {
-						balance: 1000,
-					},
+					balance: {"$lte": 1000},
 				},
 			],
 		};
+
 		const nestedLogicalFilter: LogicalFilter<Student> = {
-			op: LogicalOperator.OR,
-			logicalFilters: [logicalFilter1, logicalFilter2],
+			"$or": [logicalFilter1, logicalFilter2],
 		};
 		expect(Utility.filterToString(nestedLogicalFilter)).toBe(
 			'{"$or":[{"$and":[{"name":"alice"},{"address.city":"Paris"}]},{"$and":[{"address.zipcode":{"$gte":1200}},{"balance":{"$lte":1000}}]}]}'
@@ -285,42 +227,27 @@ describe("filters tests", () => {
 
 	it("nestedLogicalFilter2", () => {
 		const logicalFilter1: LogicalFilter<IUser2> = {
-			op: LogicalOperator.OR,
-			selectorFilters: [
+			"$or": [
 				{
-					op: SelectorFilterOperator.EQ,
-					fields: {
-						name: "alice",
-					},
+					name: "alice",
 				},
 				{
-					op: SelectorFilterOperator.EQ,
-					fields: {
-						rank: 1,
-					},
+					rank: 1,
 				},
 			],
 		};
 		const logicalFilter2: LogicalFilter<IUser2> = {
-			op: LogicalOperator.OR,
-			selectorFilters: [
+			"$or": [
 				{
-					op: SelectorFilterOperator.EQ,
-					fields: {
-						name: "emma",
-					},
+					name: "emma",
 				},
 				{
-					op: SelectorFilterOperator.EQ,
-					fields: {
-						rank: 1,
-					},
+					rank: 1,
 				},
 			],
 		};
 		const nestedLogicalFilter: LogicalFilter<IUser2> = {
-			op: LogicalOperator.AND,
-			logicalFilters: [logicalFilter1, logicalFilter2],
+			"$and": [logicalFilter1, logicalFilter2],
 		};
 		expect(Utility.filterToString(nestedLogicalFilter)).toBe(
 			'{"$and":[{"$or":[{"name":"alice"},{"rank":1}]},{"$or":[{"name":"emma"},{"rank":1}]}]}'
@@ -335,6 +262,7 @@ export interface IUser extends TigrisCollectionType {
 }
 
 @TigrisCollection("user1")
+
 export class IUser1 {
 	@PrimaryKey({ order: 1 })
 	id: bigint;

--- a/src/types.ts
+++ b/src/types.ts
@@ -720,7 +720,7 @@ type PathType<T, P extends string> = P extends keyof T
 type Operator = "$eq" | "$ne" | "$gt" | "$gte" | "$lt" | "$lte" | "$in" | "$nin" | "$all";
 
 export type Selector<T> = Partial<{
-	[K in keyof T]?: T[K] | {[P in Operator]?: T[K] | T[K][]}
+	[K in keyof T]?: T[K] | {[P in SelectorOperator]?: T[K] | T[K][]}
 }>;
 
 export type LogicalFilter<T> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -697,19 +697,34 @@ type PathType<T, P extends string> = P extends keyof T
 	: never;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type Selector<T> = Partial<{
-	[K in string]: unknown;
-}>;
 
-export type SelectorFilter<T> = Partial<{
-	op?: SelectorFilterOperator;
-	fields: Selector<T>;
+
+// export type Selector<T> = Partial<{
+// 	[K in string]: unknown;
+// }>;
+
+// export type SelectorFilter<T> = Partial<{
+// 	op?: SelectorFilterOperator;
+// 	fields: Selector<T>;
+// }>;
+
+// export type LogicalFilter<T> = {
+// 	op: LogicalOperator;
+// 	selectorFilters?: Array<SelectorFilter<T> | Selector<T>>;
+// 	logicalFilters?: Array<LogicalFilter<T>>;
+// };
+
+// export type Filter<T> = SelectorFilter<T> | LogicalFilter<T> | Selector<T>;
+
+
+type Operator = "$eq" | "$ne" | "$gt" | "$gte" | "$lt" | "$lte" | "$in" | "$nin" | "$all";
+
+export type Selector<T> = Partial<{
+	[K in keyof T]?: T[K] | {[P in Operator]?: T[K] | T[K][]}
 }>;
 
 export type LogicalFilter<T> = {
-	op: LogicalOperator;
-	selectorFilters?: Array<SelectorFilter<T> | Selector<T>>;
-	logicalFilters?: Array<LogicalFilter<T>>;
+	[P in LogicalOperator]? : Array<Filter<T>> | Filter<T>
 };
 
-export type Filter<T> = SelectorFilter<T> | LogicalFilter<T> | Selector<T>;
+export type Filter<T> = Selector<T> | LogicalFilter<T>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -464,20 +464,6 @@ export interface TigrisCollectionType {
 	// TODO: add a discriminator here
 }
 
-export enum LogicalOperator {
-	AND = "$and",
-	OR = "$or",
-}
-
-export enum SelectorFilterOperator {
-	EQ = "$eq",
-	LT = "$lt",
-	LTE = "$lte",
-	GT = "$gt",
-	GTE = "$gte",
-	NONE = "$none",
-}
-
 export type NumericType = number | bigint;
 export type FieldTypes = string | boolean | NumericType | BigInteger | Date | object;
 
@@ -697,34 +683,15 @@ type PathType<T, P extends string> = P extends keyof T
 	: never;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-
-
-// export type Selector<T> = Partial<{
-// 	[K in string]: unknown;
-// }>;
-
-// export type SelectorFilter<T> = Partial<{
-// 	op?: SelectorFilterOperator;
-// 	fields: Selector<T>;
-// }>;
-
-// export type LogicalFilter<T> = {
-// 	op: LogicalOperator;
-// 	selectorFilters?: Array<SelectorFilter<T> | Selector<T>>;
-// 	logicalFilters?: Array<LogicalFilter<T>>;
-// };
-
-// export type Filter<T> = SelectorFilter<T> | LogicalFilter<T> | Selector<T>;
-
-
-type Operator = "$eq" | "$ne" | "$gt" | "$gte" | "$lt" | "$lte" | "$in" | "$nin" | "$all";
+export type SelectorOperator = "$eq" | "$gt" | "$gte" | "$lt" | "$lte" | "$none";
+export type LogicalOperator = "$or" | "$and";
 
 export type Selector<T> = Partial<{
-	[K in keyof T]?: T[K] | {[P in SelectorOperator]?: T[K] | T[K][]}
+	[K in keyof T]?: T[K] | { [P in SelectorOperator]?: T[K] | T[K][] };
 }>;
 
 export type LogicalFilter<T> = {
-	[P in LogicalOperator]? : Array<Filter<T>> | Filter<T>
+	[P in LogicalOperator]?: Array<Filter<T>> | Filter<T>;
 };
 
-export type Filter<T> = Selector<T> | LogicalFilter<T>;
+export type Filter<T> = Selector<T> | LogicalFilter<T> | LogicalFilter<T>[] | Selector<T>[];

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -11,7 +11,6 @@ import {
 	SortOrder,
 	ReadFields,
 	Selector,
-	SelectorFilter,
 	SelectorOperator,
 	TigrisCollectionType,
 	TigrisDataTypes,
@@ -82,7 +81,7 @@ export const Utility = {
 		if (typeof filter === "object" && !Array.isArray(filter)) {
 			const keys = Object.keys(filter);
 
-			if (keys.length === 1 && keys[0] in LogicalOperator) {
+			if (keys.length === 1 && keys[0] in { $and: "", $or: "" }) {
 				// logical filter
 				const operator = keys[0] as LogicalOperator;
 				const filters = Array.isArray(filter[operator]) ? filter[operator] : [filter[operator]];
@@ -115,17 +114,22 @@ export const Utility = {
 	_getRandomInt(upperBound: number): number {
 		return Math.floor(Math.random() * upperBound);
 	},
-	_selectorFilterToString<T extends TigrisCollectionType>(filter: SelectorFilter<T>): string {
+
+	_selectorFilterToString<T extends TigrisCollectionType>(filter: Selector<T>): string {
 		switch (filter) {
 			case "$none":
 				// filter nothing
 				return "{}";
 			case "$eq":
+				return Utility.objToJsonString(Utility._selectorFilterToFlatJSONObj("$eq", filter));
 			case "$lt":
+				return Utility.objToJsonString(Utility._selectorFilterToFlatJSONObj("$lt", filter));
 			case "$lte":
+				return Utility.objToJsonString(Utility._selectorFilterToFlatJSONObj("$lte", filter));
 			case "$gt":
+				return Utility.objToJsonString(Utility._selectorFilterToFlatJSONObj("$gt", filter));
 			case "$gte":
-				return Utility.objToJsonString(Utility._selectorFilterToFlatJSONObj(filter, filter.fields));
+				return Utility.objToJsonString(Utility._selectorFilterToFlatJSONObj("$gte", filter));
 			default:
 				return "";
 		}
@@ -171,7 +175,7 @@ export const Utility = {
 						const v = value as LogicalFilter<T>;
 						innerFilters.push(Utility._logicalFilterToJSONObj(v));
 					} else {
-						const v = value as SelectorFilter<T>;
+						const v = value as Selector<T>;
 						const operator = Object.keys(value)[0] as SelectorOperator;
 						innerFilters.push(Utility._selectorFilterToFlatJSONObj(operator, v[operator]));
 					}
@@ -181,7 +185,7 @@ export const Utility = {
 			}
 		} else {
 			// for cases where the slectorOperator is "$eq"
-			result[SelectorFilter.$eq] = Utility._selectorFilterToFlatJSONObj(SelectorFilter.$eq, filter);
+			result["$eq"] = Utility._selectorFilterToFlatJSONObj("$eq", filter);
 		}
 
 		return result;


### PR DESCRIPTION
So, I've gone ahead to modify the `filterToString` function. I've also modified the types that are being exported.

I removed the `SelectorFilter<T>` type since it won't be used in the updated spec that you shared here 👇🏼 Because, from the spec below, it will only require the `Selector` and `LogicalFilter` types. 

```ts
const productsCursor = catalog.findMany({
  filter: {
    "$or": [ 
      {  brand: "adidas" },
      { price: { "$lt" : 50 } },
    ],
  },
});
```

But, there are issues that I may still need to check if you'd love me to. One is the test cases. I'll need to modify them to become, something similar to the one mentioned in the issue &mdash; originally. Instead of the ones we have currently. For example, this one 👇🏼 

```ts
it("simplerSelectorWithinLogicalFilterTest", () => {
		const filter1: LogicalFilter<IUser> = {
			op: LogicalOperator.AND,
			selectorFilters: [
				{
					name: "Alice",
				},
				{
					balance: 100,
				},
			],
		};
		expect(Utility.filterToString(filter1)).toBe('{"$and":[{"name":"Alice"},{"balance":100}]}');

		const filter2: LogicalFilter<IUser> = {
			op: LogicalOperator.OR,
			selectorFilters: [
				{
					name: "Alice",
				},
				{
					name: "Emma",
				},
			],
		};
		expect(Utility.filterToString(filter2)).toBe('{"$or":[{"name":"Alice"},{"name":"Emma"}]}');
	});
```

The `_logicalFilterToJSONObj` method too is affected. I'm getting an error message saying "Property 'op' does not exist on type 'LogicalFilter<T>'` which is a result of the change in the `LogicalFilter<T>` and `Selector<T>` filter. 

I even tried modifying it to use the `_selectorFilterToFlatJSONObj` method. But I kept getting stuck. Perhaps you go through my implementation first and let me know what you think.

/claim #268

cc: @ovaistariq, @adilansari 