### PR TITLE
refactor: primary key order optional under interface defined schema

### DIFF
--- a/src/__tests__/fixtures/schema/student.ts
+++ b/src/__tests__/fixtures/schema/student.ts
@@ -32,33 +32,6 @@ export class Student {
 
 /********************************** END **************************************/
 
-/******************************************************************************
- * `InvalidStudent` class demonstrates a Tigris collection schema validation,
- *  Schema is INVALID as it contains two primary keys but no order was specified
- *  in decorator under PrimaryKeyOptions.
- *****************************************************************************/
-export const INVALID_STUDENT_COLLECTION_NAME = "invalid_students";
-
-@TigrisCollection(INVALID_STUDENT_COLLECTION_NAME)
-export class InvalidStudent {
-	@PrimaryKey(TigrisDataTypes.INT64)
-	id?: string;
-
-	@PrimaryKey(TigrisDataTypes.STRING)
-	email: string;
-
-	@Field()
-	firstName!: string;
-
-	@Field()
-	lastName!: string;
-
-	@Field({ timestamp: "createdAt" })
-	createdAt?: Date;
-}
-
-/********************************** END **************************************/
-
 /**
  * `TigrisSchema` representation of the `Student` collection class .
  *

--- a/src/__tests__/tigris.schema.spec.ts
+++ b/src/__tests__/tigris.schema.spec.ts
@@ -18,12 +18,8 @@ import { Order, ORDERS_COLLECTION_NAME, OrderSchema } from "./fixtures/schema/or
 import { Movie, MOVIES_COLLECTION_NAME, MovieSchema } from "./fixtures/schema/movies";
 import { MATRICES_COLLECTION_NAME, Matrix, MatrixSchema } from "./fixtures/schema/matrices";
 import { readJSONFileAsObj } from "./utils";
-import {
-	InvalidStudent,
-	STUDENT_COLLECTION_NAME,
-	Student,
-	StudentSchema,
-} from "./fixtures/schema/student";
+import { STUDENT_COLLECTION_NAME, Student, StudentSchema } from "./fixtures/schema/student";
+import { PrimaryKey } from "../decorators/tigris-primary-key";
 
 type SchemaTestCase<T extends TigrisCollectionType> = {
 	schemaClass: T;
@@ -97,6 +93,29 @@ test("throws error when Schema is invalid with more than one primary key but no 
 	const processor = DecoratedSchemaProcessor.Instance;
 	let caught;
 	try {
+		/**
+		 * Schema is INVALID as it contains two primary keys but no order was specified
+		 * in decorator under PrimaryKeyOptions.
+		 */
+		const INVALID_STUDENT_COLLECTION_NAME = "invalid_students";
+		@TigrisCollection(INVALID_STUDENT_COLLECTION_NAME)
+		class InvalidStudent {
+			@PrimaryKey(TigrisDataTypes.INT64)
+			id?: string;
+
+			@PrimaryKey(TigrisDataTypes.STRING)
+			email: string;
+
+			@Field()
+			firstName!: string;
+
+			@Field()
+			lastName!: string;
+
+			@Field({ timestamp: "createdAt" })
+			createdAt?: Date;
+		}
+
 		processor.processCollection(InvalidStudent);
 	} catch (err) {
 		caught = err;

--- a/src/error.ts
+++ b/src/error.ts
@@ -80,14 +80,23 @@ export class IncorrectVectorDefError extends TigrisError {
 		return "IncorrectVectorDefError";
 	}
 }
-
-export class IncompletePrimaryKeyDefError extends TigrisError {
-	constructor(object: Object, propertyName: string) {
-		super(`Missing "PrimaryKeyOptions" for '${object.constructor.name}#${propertyName}'`);
+export class MissingPrimaryKeyOrderInSchemaDefinitionError extends TigrisError {
+	constructor(propertyName: string) {
+		super(`Missing 'order' value for '${propertyName}' primary key`);
 	}
 
 	override get name(): string {
-		return "IncompletePrimaryKeyDefError";
+		return "MissingPrimaryKeyOrderInSchemaDefinitionError";
+	}
+}
+
+export class DuplicatePrimaryKeyOrderError extends TigrisError {
+	constructor(order: string, propertyName: string) {
+		super(`Primary Key order '${order}' already exists for '${propertyName}'`);
+	}
+
+	override get name(): string {
+		return "DuplicatePrimaryKeyOrderError";
 	}
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -680,7 +680,7 @@ export type TigrisArrayItem = {
 };
 
 export type PrimaryKeyOptions = {
-	order: number;
+	order?: number;
 	autoGenerate?: boolean;
 };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
( Refactored as per comments on this [PR](https://github.com/tigrisdata/tigris-client-ts/pull/308#issuecomment-1511987616) )
- Specifying 'order' is optional if there is only one primary key for collection when the schema defined through the interfaces. ( if not specified, default order is 1 )
- Order is required when there are multiple primary keys.
- Moved the test example class to the spec file.
## Related Tickets & Documents


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue:  https://github.com/tigrisdata/tigris-client-ts/pull/308#issuecomment-1511987616


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why?_

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?
Not sure, but we can specify in the docs as well.
- [] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      and link here as `tigrisdata/tigris-docs#123`_
- [] No
