### PR TITLE
fix: DropCollections waits for all

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -237,17 +237,12 @@ export class DB {
 		});
 	}
 
-	public dropAllCollections(): Promise<void> {
-		return new Promise<void>((resolve, reject) => {
-			this.listCollections()
-				.then((value: Array<CollectionInfo>) => {
-					for (const collectionInfo of value) {
-						this.dropCollection(collectionInfo.name);
-					}
-					resolve();
-				})
-				.catch((error) => reject(error));
+	public async dropAllCollections(): Promise<PromiseSettledResult<DropCollectionResponse>[]> {
+		const collections = await this.listCollections();
+		const dropPromises = collections.map((coll) => {
+			return this.dropCollection(coll.name);
 		});
+		return Promise.allSettled(dropPromises);
 	}
 
 	public describe(): Promise<DatabaseDescription> {


### PR DESCRIPTION
Fixes dropCollections to wait for all the collections to be dropped before resolving the promise.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The dropCollections was not waiting for all the collections to be dropped before resolving. This was causing a race condition. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why?_

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?

- [ ] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      and link here as `tigrisdata/tigris-docs#123`_
- [x] No

## [optional] Are there any post deployment tasks we need to perform?
