### PR TITLE
Adding missing comparison operators to client

### DIFF
--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -160,7 +160,7 @@ describe("filters tests", () => {
 				$not: "Jack",
 			},
 		};
-		expect(Utility.filterToString(tigrisFilter)).toBe('{"balance":{"$not":"Jack"}}');
+		expect(Utility.filterToString(tigrisFilter)).toBe('{"name":{"$not":"Jack"}}');
 	});
 
 	it("contains Filter(string)", () => {

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -166,8 +166,8 @@ describe("filters tests", () => {
 	it("contains Filter(string)", () => {
 		const tigrisFilter: Filter<Student> = {
 			name: {
-				$contains: "Adam"
-			}
+				$contains: "Adam",
+			},
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"name":{"$contains":"Adam"}}');
 	});
@@ -175,17 +175,19 @@ describe("filters tests", () => {
 	it("contains Filter(string[])", () => {
 		const tigrisFilter: Filter<Student> = {
 			name: {
-				$contains: ["Adam", "Warlock", "Steven"]
-			}
+				$contains: ["Adam", "Warlock", "Steven"],
+			},
 		};
-		expect(Utility.filterToString(tigrisFilter)).toBe('{"name":{"$contains":["Adam","Warlock","Steven"]}}');
+		expect(Utility.filterToString(tigrisFilter)).toBe(
+			'{"name":{"$contains":["Adam","Warlock","Steven"]}}'
+		);
 	});
 
 	it("regex Filter", () => {
 		const tigrisFilter: Filter<Student> = {
 			name: {
-				$regex: "/andy/i"
-			}
+				$regex: "/andy/i",
+			},
 		};
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"name":{"$regex":"/andy/i"}}');
 	});
@@ -247,7 +249,7 @@ describe("filters tests", () => {
 					balance: {
 						$lte: 1000,
 					},
-				}
+				},
 			],
 		};
 		const nestedLogicalFilter: Filter<Student> = {

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -172,17 +172,6 @@ describe("filters tests", () => {
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"name":{"$contains":"Adam"}}');
 	});
 
-	it("contains Filter(string[])", () => {
-		const tigrisFilter: Filter<Student> = {
-			name: {
-				$contains: ["Adam", "Warlock", "Steven"],
-			},
-		};
-		expect(Utility.filterToString(tigrisFilter)).toBe(
-			'{"name":{"$contains":["Adam","Warlock","Steven"]}}'
-		);
-	});
-
 	it("regex Filter", () => {
 		const tigrisFilter: Filter<Student> = {
 			name: {

--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -154,6 +154,42 @@ describe("filters tests", () => {
 		expect(Utility.filterToString(tigrisFilter)).toBe('{"balance":{"$gte":10}}');
 	});
 
+	it("not Filter", () => {
+		const tigrisFilter: Filter<Student> = {
+			name: {
+				$not: "Jack",
+			},
+		};
+		expect(Utility.filterToString(tigrisFilter)).toBe('{"balance":{"$not":"Jack"}}');
+	});
+
+	it("contains Filter(string)", () => {
+		const tigrisFilter: Filter<Student> = {
+			name: {
+				$contains: "Adam"
+			}
+		};
+		expect(Utility.filterToString(tigrisFilter)).toBe('{"name":{"$contains":"Adam"}}');
+	});
+
+	it("contains Filter(string[])", () => {
+		const tigrisFilter: Filter<Student> = {
+			name: {
+				$contains: ["Adam", "Warlock", "Steven"]
+			}
+		};
+		expect(Utility.filterToString(tigrisFilter)).toBe('{"name":{"$contains":["Adam","Warlock","Steven"]}}');
+	});
+
+	it("regex Filter", () => {
+		const tigrisFilter: Filter<Student> = {
+			name: {
+				$regex: "/andy/i"
+			}
+		};
+		expect(Utility.filterToString(tigrisFilter)).toBe('{"name":{"$regex":"/andy/i"}}');
+	});
+
 	it("logicalFilterTest1", () => {
 		const logicalFilter: Filter<IUser> = {
 			$or: [
@@ -211,7 +247,7 @@ describe("filters tests", () => {
 					balance: {
 						$lte: 1000,
 					},
-				},
+				}
 			],
 		};
 		const nestedLogicalFilter: Filter<Student> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -766,7 +766,7 @@ export type SelectorOperator = "$eq" | "$gt" | "$gte" | "$lt" | "$lte" | "$not" 
 export type LogicalOperator = "$or" | "$and";
 
 export type SelectorFilter<T> = {
-	[K in PathsForFilter<T>]?: PathType<T, K> | { [P in SelectorOperator]?: PathType<T, K> };
+	[K in PathsForFilter<T>]?: PathType<T, K> | { [P in SelectorOperator]?: P extends "$contains" ? PathType<T, K> | PathType<T, K>[] : PathType<T, K> };
 };
 
 export type LogicalFilter<T> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -762,7 +762,7 @@ type PathsForFilter<T, P extends string = ""> = {
 		: `${P}${K & string}`;
 }[keyof T];
 
-export type SelectorOperator = "$eq" | "$gt" | "$gte" | "$lt" | "$lte" | "$none";
+export type SelectorOperator = "$eq" | "$gt" | "$gte" | "$lt" | "$lte" | "$not" | "$regex" | "$contains" | "$none";
 export type LogicalOperator = "$or" | "$and";
 
 export type SelectorFilter<T> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -762,11 +762,26 @@ type PathsForFilter<T, P extends string = ""> = {
 		: `${P}${K & string}`;
 }[keyof T];
 
-export type SelectorOperator = "$eq" | "$gt" | "$gte" | "$lt" | "$lte" | "$not" | "$regex" | "$contains" | "$none";
+export type SelectorOperator =
+	| "$eq"
+	| "$gt"
+	| "$gte"
+	| "$lt"
+	| "$lte"
+	| "$not"
+	| "$regex"
+	| "$contains"
+	| "$none";
 export type LogicalOperator = "$or" | "$and";
 
 export type SelectorFilter<T> = {
-	[K in PathsForFilter<T>]?: PathType<T, K> | { [P in SelectorOperator]?: P extends "$contains" ? PathType<T, K> | PathType<T, K>[] : PathType<T, K> };
+	[K in PathsForFilter<T>]?:
+		| PathType<T, K>
+		| {
+				[P in SelectorOperator]?: P extends "$contains"
+					? PathType<T, K> | PathType<T, K>[]
+					: PathType<T, K>;
+		  };
 };
 
 export type LogicalFilter<T> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -775,13 +775,7 @@ export type SelectorOperator =
 export type LogicalOperator = "$or" | "$and";
 
 export type SelectorFilter<T> = {
-	[K in PathsForFilter<T>]?:
-		| PathType<T, K>
-		| {
-				[P in SelectorOperator]?: P extends "$contains"
-					? PathType<T, K> | PathType<T, K>[]
-					: PathType<T, K>;
-		  };
+	[K in PathsForFilter<T>]?: PathType<T, K> | { [P in SelectorOperator]?: P extends "$contains" ? PathType<T, K> | PathType<T, K>[] : PathType<T, K> };
 };
 
 export type LogicalFilter<T> = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add the following missing comparison operators:
- $not
- $contains
- $regex

/claim #325

## Related Tickets & Documents
https://github.com/tigrisdata/tigris-client-ts/issues/325

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #325
- Closes #325

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why?_

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?

- [x] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      [tigrisdata/tigris-docs#123](https://github.com/tigrisdata/tigris-docs/issues/385)
- [ ] No

### Checklist

- [x] `npm run build` - builds successfully
- [x] `npm run test` - tests passing
- [x] `npm run lint` - no lint errors

## [optional] Are there any post deployment tasks we need to perform?

![Screenshot 2023-04-30 at 2 38 01 PM](https://user-images.githubusercontent.com/119384208/235362915-60a05cc8-687a-40d7-a88a-77b514ce0336.png)
![Screenshot 2023-04-30 at 3 41 12 PM](https://user-images.githubusercontent.com/119384208/235362930-2ec8aeaf-778c-45ed-8481-9e0eff14a9f6.png)

