### PR TITLE
ci: trigger workflows on pull requests

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,6 +1,6 @@
 name: release-test
 on:
-  pull_request_target:
+  pull_request:
     types:
       - "opened"
       - "reopened"

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -1,6 +1,13 @@
 name: ts-ci
 
-on: [push]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
- Allows running `ts-ci` workflow on pull requests coming from forks.
- Replaces trigger for **pre-release** workflow to be `pull_request`. As per [following recommendation](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), the pre-release should not be needing write permissions as its a dry run:

```
Workflows triggered via pull_request_target have write permission to the target repository. They also have access to target repository secrets. The same is true for workflows triggered on pull_request from a branch in the same repository, but not from external forks. The reasoning behind the latter is that it is safe to share the repository secrets if the user creating the PR has write permission to the target repository already.
```
