### PR TITLE
Add new index creation method that allows overriding index name

### DIFF
--- a/src/__tests__/test-search-service.ts
+++ b/src/__tests__/test-search-service.ts
@@ -49,6 +49,7 @@ export const SearchServiceFixtures = {
 	]),
 	CreateIndex: {
 		Blog: "blogPosts",
+		BlogOverride: "blogPostsOverride",
 	},
 	SearchDocs: {
 		UpdatedAtSeconds: Math.floor(Date.now() / 1000),
@@ -173,6 +174,16 @@ class TestSearchService {
 						.setStatus("created")
 						.setMessage("index created");
 					callback(undefined, resp);
+					return;
+				case SearchServiceFixtures.CreateIndex.BlogOverride:
+					const schema2 = Buffer.from(call.request.getSchema_asB64(), "base64").toString();
+					expect(schema2).toBe(
+						'{"title":"blogPostsOverride","type":"object","properties":{"text":{"type":"string","searchIndex":true,"facet":true},"comments":{"type":"array","items":{"type":"string"},"searchIndex":true},"author":{"type":"string","searchIndex":true},"createdAt":{"type":"string","format":"date-time","searchIndex":true,"sort":true}}}'
+					);
+					const resp2 = new CreateOrUpdateIndexResponse()
+						.setStatus("created")
+						.setMessage("index created");
+					callback(undefined, resp2);
 					return;
 				case SearchServiceFixtures.AlreadyExists:
 					callback(new Error("already exists"));

--- a/src/__tests__/tigris.search.spec.ts
+++ b/src/__tests__/tigris.search.spec.ts
@@ -65,6 +65,24 @@ describe("Search Indexing", () => {
 		});
 	});
 
+	describe("createOrUpdateIndexFromClass", () => {
+		it("creates index from decorated schema model", async () => {
+			const createPromise = tigris.createOrUpdateIndexFromClass(BlogPost);
+			await expect(createPromise).resolves.toBeInstanceOf(SearchIndex);
+		});
+		it("creates index from decorated schema model with name overriden", async () => {
+			const createPromise = tigris.createOrUpdateIndexFromClass(
+				BlogPost,
+				SearchServiceFixtures.CreateIndex.BlogOverride
+			);
+			await expect(createPromise).resolves.toBeInstanceOf(SearchIndex);
+			await expect(createPromise).resolves.toHaveProperty(
+				"name",
+				SearchServiceFixtures.CreateIndex.BlogOverride
+			);
+		});
+	});
+
 	describe("getIndex", () => {
 		it("succeeds if index exists", async () => {
 			const getIndexPromise = tigris.getIndex(SearchServiceFixtures.Success);

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -63,6 +63,18 @@ export class Search {
 		});
 	}
 
+	public createOrUpdateIndexFromClass<T extends TigrisIndexType>(
+		cls: new () => TigrisIndexType,
+		name?: string
+	): Promise<SearchIndex<T>> {
+		const generatedIndex = this.schemaProcessor.processIndex(cls);
+		if (!name) {
+			name = generatedIndex.name;
+		}
+
+		return this.createOrUpdateIndex(name, generatedIndex.schema as TigrisIndexSchema<T>);
+	}
+
 	public listIndexes(): Promise<Array<IndexInfo>> {
 		// TODO: Set filter on request
 		const listIndexRequest = new ProtoListIndexesRequest().setProject(this.projectName);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a new method, `createOrUpdateIndexFromClass` that allows providing a name for the index that will override the one in the model.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why?_

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?

- [ ] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      and replace this text as `tigrisdata/tigris-docs#123`_
- [ ] No

### Checklist

- [x] `npm run build` - builds successfully
- [x] `npm run test` - tests passing
- [x] `npm run lint` - no lint errors

## [optional] Are there any post deployment tasks we need to perform?
