### PR TITLE
feat: Pass index name along with decorated class

### DIFF
--- a/src/__tests__/search/search.spec.ts
+++ b/src/__tests__/search/search.spec.ts
@@ -1,0 +1,139 @@
+import {
+	Search,
+	SearchField,
+	SearchIndex,
+	TigrisIndexSchema,
+	TigrisSearchIndex,
+} from "../../search";
+import { capture, instance, mock, reset, spy } from "ts-mockito";
+import { SearchClient as ProtoSearchClient } from "../../proto/server/v1/search_grpc_pb";
+import { CreateOrUpdateIndexResponse as ProtoCreateIndexResponse } from "../../proto/server/v1/search_pb";
+import { Utility } from "../../utility";
+import { TigrisDataTypes } from "../../types";
+import { Status as ProtoStatus } from "@grpc/grpc-js/build/src/constants";
+import { ServiceError } from "@grpc/grpc-js";
+
+describe("Search", () => {
+	let target: Search;
+	let mockClient: ProtoSearchClient;
+
+	beforeEach(() => {
+		mockClient = mock(ProtoSearchClient);
+		target = new Search(instance(mockClient), { projectName: "test_project" });
+	});
+
+	afterEach(() => {
+		reset(mockClient);
+	});
+
+	describe("createOrUpdateIndex", () => {
+		const decoratedModelName = "decorated_model";
+		@TigrisSearchIndex(decoratedModelName)
+		class Book {
+			@SearchField()
+			name: string;
+		}
+
+		const IBook: TigrisIndexSchema<Book> = {
+			name: {
+				type: TigrisDataTypes.STRING,
+				searchIndex: true,
+			},
+		};
+
+		it("creates index using decorated model class", async () => {
+			const expectedSchema = JSON.stringify({
+				title: decoratedModelName,
+				type: "object",
+				properties: {
+					name: {
+						type: "string",
+						searchIndex: true,
+					},
+				},
+			});
+
+			const resp = target.createOrUpdateIndex(Book);
+			// verifies that grpc gets invoked with the right arguments
+			const [capturedReq, capturedCallback] = capture(mockClient.createOrUpdateIndex).last();
+			// @ts-ignore
+			capturedCallback(null, new ProtoCreateIndexResponse());
+
+			expect(capturedReq.getName()).toBe(decoratedModelName);
+			expect(capturedReq.getProject()).toBe(target.projectName);
+			expect(capturedReq.getOnlyCreate()).toBe(false);
+			expect(Utility.uint8ArrayToString(capturedReq.getSchema_asU8())).toBe(expectedSchema);
+
+			return expect(resp).resolves.toBeInstanceOf(SearchIndex);
+		});
+
+		it("creates index using decorated model and specified name", async () => {
+			const overridenName = "my_custom_name";
+			const expectedSchema = JSON.stringify({
+				title: overridenName,
+				type: "object",
+				properties: {
+					name: {
+						type: "string",
+						searchIndex: true,
+					},
+				},
+			});
+			const resp = target.createOrUpdateIndex(overridenName, Book);
+			// verifies that grpc gets invoked with the right arguments
+			const [capturedReq, capturedCallback] = capture(mockClient.createOrUpdateIndex).last();
+			// @ts-ignore
+			capturedCallback(null, new ProtoCreateIndexResponse());
+
+			expect(capturedReq.getName()).toBe(overridenName);
+			expect(capturedReq.getProject()).toBe(target.projectName);
+			expect(capturedReq.getOnlyCreate()).toBe(false);
+			expect(Utility.uint8ArrayToString(capturedReq.getSchema_asU8())).toBe(expectedSchema);
+
+			return expect(resp).resolves.toBeInstanceOf(SearchIndex);
+		});
+
+		it("creates index using interface schema", async () => {
+			const expectedIndexName = "interface_schema";
+			const expectedSchema = JSON.stringify({
+				title: expectedIndexName,
+				type: "object",
+				properties: {
+					name: {
+						type: "string",
+						searchIndex: true,
+					},
+				},
+			});
+			const resp = target.createOrUpdateIndex(expectedIndexName, IBook);
+			// verifies that grpc gets invoked with the right arguments
+			const [capturedReq, capturedCallback] = capture(mockClient.createOrUpdateIndex).last();
+			// @ts-ignore
+			capturedCallback(null, new ProtoCreateIndexResponse());
+
+			expect(capturedReq.getName()).toBe(expectedIndexName);
+			expect(capturedReq.getProject()).toBe(target.projectName);
+			expect(capturedReq.getOnlyCreate()).toBe(false);
+			expect(Utility.uint8ArrayToString(capturedReq.getSchema_asU8())).toBe(expectedSchema);
+
+			return expect(resp).resolves.toBeInstanceOf(SearchIndex);
+		});
+
+		it("fails when underlying grpc throws error", async () => {
+			const expectedError: ServiceError = {
+				details: "",
+				metadata: undefined,
+				name: "",
+				code: ProtoStatus.INVALID_ARGUMENT,
+				message: "invalid schema",
+			};
+			const resp = target.createOrUpdateIndex(Book);
+			const [capturedReq, capturedCallback] = capture(mockClient.createOrUpdateIndex).last();
+			// @ts-ignore
+			capturedCallback(expectedError, new ProtoCreateIndexResponse());
+
+			expect(capturedReq.getSchema()).toBeDefined();
+			return expect(resp).rejects.toStrictEqual(expectedError);
+		});
+	});
+});

--- a/src/__tests__/tigris.search.spec.ts
+++ b/src/__tests__/tigris.search.spec.ts
@@ -65,24 +65,6 @@ describe("Search Indexing", () => {
 		});
 	});
 
-	describe("createOrUpdateIndexFromClass", () => {
-		it("creates index from decorated schema model", async () => {
-			const createPromise = tigris.createOrUpdateIndexFromClass(BlogPost);
-			await expect(createPromise).resolves.toBeInstanceOf(SearchIndex);
-		});
-		it("creates index from decorated schema model with name overriden", async () => {
-			const createPromise = tigris.createOrUpdateIndexFromClass(
-				BlogPost,
-				SearchServiceFixtures.CreateIndex.BlogOverride
-			);
-			await expect(createPromise).resolves.toBeInstanceOf(SearchIndex);
-			await expect(createPromise).resolves.toHaveProperty(
-				"name",
-				SearchServiceFixtures.CreateIndex.BlogOverride
-			);
-		});
-	});
-
 	describe("getIndex", () => {
 		it("succeeds if index exists", async () => {
 			const getIndexPromise = tigris.getIndex(SearchServiceFixtures.Success);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- Three ways to create a search index:
1. Using decorated model class: `search.createOrUpdateIndex(MyDecoratedModelClass)`
2. Using name and interface: `search.createOrUpdateIndex("name", MyIndexSchemaInterface)`
3. Using name and decorated model class: `search.createOrUpdateIndex("name", MyDecoratedModelClass)`

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [ ] Yes
- [x] No, and this is why: **removes the createOrUpdateIndexFromClass()** method 

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?

- [x] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      and replace this text as `tigrisdata/tigris-docs#123`_
- [ ] No

### Checklist

- [x] `npm run build` - builds successfully
- [x] `npm run test` - tests passing
- [x] `npm run lint` - no lint errors

## [optional] Are there any post deployment tasks we need to perform?
