### PR TITLE
feat: static type binding for query

### DIFF
--- a/src/__tests__/tigris.readfields.spec.ts
+++ b/src/__tests__/tigris.readfields.spec.ts
@@ -1,24 +1,39 @@
-import { ReadFields } from "../types";
+import { ReadFields, TigrisCollectionType } from "../types";
 import { Utility } from "../utility";
 
+export interface IBook1 extends TigrisCollectionType {
+	id?: number;
+	title: string;
+	author: Author;
+	tags?: string[];
+}
+
+export interface Author extends TigrisCollectionType {
+	firstName: string;
+	lastName: string;
+}
 describe("readFields tests", () => {
 	it("readFields1", () => {
-		const readFields: ReadFields = {
-			include: ["id", "title"],
+		const readFields: ReadFields<IBook1> = {
+			include: ["id", "title", "author.firstName", "author.lastName"],
 		};
-		expect(Utility.readFieldString(readFields)).toBe('{"id":true,"title":true}');
+		expect(Utility.readFieldString<IBook1>(readFields)).toBe(
+			'{"id":true,"title":true,"author.firstName":true,"author.lastName":true}'
+		);
 	});
 	it("readFields2", () => {
-		const readFields: ReadFields = {
+		const readFields: ReadFields<IBook1> = {
 			exclude: ["id", "title"],
 		};
-		expect(Utility.readFieldString(readFields)).toBe('{"id":false,"title":false}');
+		expect(Utility.readFieldString<IBook1>(readFields)).toBe('{"id":false,"title":false}');
 	});
 	it("readFields3", () => {
-		const readFields: ReadFields = {
+		const readFields: ReadFields<IBook1> = {
 			include: ["id", "title"],
 			exclude: ["author"],
 		};
-		expect(Utility.readFieldString(readFields)).toBe('{"id":true,"title":true,"author":false}');
+		expect(Utility.readFieldString<IBook1>(readFields)).toBe(
+			'{"id":true,"title":true,"author":false}'
+		);
 	});
 });

--- a/src/__tests__/tigris.utility.spec.ts
+++ b/src/__tests__/tigris.utility.spec.ts
@@ -9,10 +9,23 @@ import {
 	SearchQueryOptions,
 } from "../search";
 import { SearchRequest as ProtoSearchRequest } from "../proto/server/v1/api_pb";
-import { SortOrder } from "../types";
+import { SortOrder, TigrisCollectionType } from "../types";
 import { Field } from "../decorators/tigris-field";
 import { TigrisCollection } from "../decorators/tigris-collection";
 import { PrimaryKey } from "../decorators/tigris-primary-key";
+
+interface ICollectionFields extends TigrisCollectionType {
+	field_1: string;
+	field_2: string;
+	field_3: string;
+	parent?: IParent;
+}
+
+interface IParent extends TigrisCollectionType {
+	field_1?: string;
+	field_2?: string;
+	field_3?: string;
+}
 
 describe("utility tests", () => {
 	it("base64encode", () => {
@@ -40,7 +53,7 @@ describe("utility tests", () => {
 	});
 
 	it("serializes FacetFields to string", () => {
-		const fields: FacetFields = ["field_1", "field_2"];
+		const fields: FacetFields<ICollectionFields> = ["field_1", "field_2"];
 		const serialized: string = Utility.facetQueryToString(fields);
 		expect(serialized).toBe(
 			'{"field_1":{"size":10,"type":"value"},"field_2":{"size":10,"type":"value"}}'
@@ -48,7 +61,7 @@ describe("utility tests", () => {
 	});
 
 	it("serializes FacetFieldOptions to string", () => {
-		const fields: FacetFieldOptions = {
+		const fields: FacetFieldOptions<ICollectionFields> = {
 			field_1: Utility.defaultFacetingOptions(),
 			field_2: { size: 10 },
 		};
@@ -59,8 +72,8 @@ describe("utility tests", () => {
 	});
 
 	it("equivalent serialization of FacetFieldsQuery", () => {
-		const facetFields: FacetFieldsQuery = ["field_1", "field_2"];
-		const fieldOptions: FacetFieldsQuery = {
+		const facetFields: FacetFieldsQuery<ICollectionFields> = ["field_1", "field_2"];
+		const fieldOptions: FacetFieldsQuery<ICollectionFields> = {
 			field_1: Utility.defaultFacetingOptions(),
 			field_2: { size: 10, type: "value" },
 		};
@@ -68,8 +81,7 @@ describe("utility tests", () => {
 		expect(serializedFields).toBe(Utility.facetQueryToString(fieldOptions));
 	});
 
-	it.each<[string, SortOrder, string]>([
-		["undefined", undefined, "[]"],
+	it.each<[string, SortOrder<ICollectionFields>, string]>([
 		[
 			"multiple sort fields",
 			[
@@ -81,7 +93,7 @@ describe("utility tests", () => {
 		["single sort field", { field: "field_3", order: "$desc" }, '[{"field_3":"$desc"}]'],
 		["empty array", [], "[]"],
 	])("_sortOrderingToString() with '%s'", (testName, input, expected) => {
-		expect(Utility._sortOrderingToString(input)).toBe(expected);
+		expect(Utility._sortOrderingToString<ICollectionFields>(input)).toBe(expected);
 	});
 
 	describe("createProtoSearchRequest", () => {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -569,11 +569,13 @@ export class Collection<T extends TigrisCollectionType> implements ICollection {
 			.setFilter(Utility.stringToUint8Array(Utility.filterToString(query.filter)));
 
 		if (query.readFields) {
-			readRequest.setFields(Utility.stringToUint8Array(Utility.readFieldString(query.readFields)));
+			readRequest.setFields(
+				Utility.stringToUint8Array(Utility.readFieldString<T>(query.readFields))
+			);
 		}
 
 		if (query.sort) {
-			readRequest.setSort(Utility.stringToUint8Array(Utility._sortOrderingToString(query.sort)));
+			readRequest.setSort(Utility.stringToUint8Array(Utility._sortOrderingToString<T>(query.sort)));
 		}
 
 		if (query.options) {

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -1,4 +1,4 @@
-import { Filter, SortOrder, TigrisCollectionType } from "../types";
+import { DocumentPaths, Filter, SortOrder, TigrisCollectionType } from "../types";
 import { TigrisIndexType } from "./types";
 
 export const MATCH_ALL_QUERY_STRING = "";
@@ -14,7 +14,7 @@ export interface SearchQuery<T extends TigrisCollectionType | TigrisIndexType> {
 	/**
 	 * Fields to project search query on
 	 */
-	searchFields?: Array<string>;
+	searchFields?: Array<DocumentPaths<T>>;
 	/**
 	 * Filter to further refine the search results
 	 */
@@ -22,7 +22,7 @@ export interface SearchQuery<T extends TigrisCollectionType | TigrisIndexType> {
 	/**
 	 * Facet fields to categorically arrange indexed terms
 	 */
-	facets?: FacetFieldsQuery;
+	facets?: FacetFieldsQuery<T>;
 	/**
 	 * Perform a nearest neighbor search to find closest documents
 	 */
@@ -30,7 +30,7 @@ export interface SearchQuery<T extends TigrisCollectionType | TigrisIndexType> {
 	/**
 	 * Sort the search results in indicated order
 	 */
-	sort?: SortOrder;
+	sort?: SortOrder<T>;
 	/**
 	 * Group by single or multiple fields in the index
 	 */
@@ -38,11 +38,11 @@ export interface SearchQuery<T extends TigrisCollectionType | TigrisIndexType> {
 	/**
 	 * Document fields to include when returning search results
 	 */
-	includeFields?: Array<string>;
+	includeFields?: Array<DocumentPaths<T>>;
 	/**
 	 * Document fields to exclude when returning search results
 	 */
-	excludeFields?: Array<string>;
+	excludeFields?: Array<DocumentPaths<T>>;
 	/**
 	 * Maximum number of search hits (matched documents) to fetch per page
 	 */
@@ -63,19 +63,19 @@ export interface SearchQueryOptions {
 	collation?: Collation;
 }
 
-export type FacetFieldsQuery = FacetFieldOptions | FacetFields;
+export type FacetFieldsQuery<T> = FacetFieldOptions<T> | FacetFields<T>;
 
 /**
  * Map of collection field names and faceting options to include facet results in search response
  */
-export type FacetFieldOptions = {
-	[key: string]: FacetQueryOptions;
+export type FacetFieldOptions<T> = {
+	[K in DocumentPaths<T>]?: FacetQueryOptions;
 };
 
 /**
  * Array of field names to include facet results for in search response
  */
-export type FacetFields = Array<string>;
+export type FacetFields<T> = Array<DocumentPaths<T>>;
 
 /**
  * Information to build facets in search results

--- a/src/types.ts
+++ b/src/types.ts
@@ -494,9 +494,9 @@ export interface TigrisCollectionType {
 export type NumericType = number | bigint;
 export type FieldTypes = string | boolean | NumericType | BigInteger | Date | object;
 
-export type ReadFields = {
-	include?: Array<string>;
-	exclude?: Array<string>;
+export type ReadFields<T> = {
+	include?: Array<DocumentPaths<T>>;
+	exclude?: Array<DocumentPaths<T>>;
 };
 
 type DocumentFields<T, V> = Partial<{
@@ -517,13 +517,13 @@ export type UpdateFields<T> =
 /**
  * List of fields and their corresponding sort order to order the search results.
  */
-export type SortOrder = SortField | Array<SortField>;
+export type SortOrder<T> = SortField<T> | Array<SortField<T>>;
 
 /**
  * Collection field name and sort order
  */
-export type SortField = {
-	field: string;
+export type SortField<T> = {
+	field: DocumentPaths<T>;
 	order: "$asc" | "$desc";
 };
 
@@ -548,12 +548,12 @@ export interface FindQuery<T> {
 	 * Field projection to allow returning only specific document fields. By default
 	 * all document fields are returned.
 	 */
-	readFields?: ReadFields;
+	readFields?: ReadFields<T>;
 
 	/**
 	 * Sort the query results as per indicated order
 	 */
-	sort?: SortOrder;
+	sort?: SortOrder<T>;
 
 	/**
 	 * Optional params
@@ -750,17 +750,19 @@ export type Selector<T> = Partial<{
 	[K in string]: unknown;
 }>;
 
-type PathsForFilter<T, P extends string = ""> = {
-	[K in keyof T]: T[K] extends object
-		? T[K] extends unknown[]
-			? `${P}${K & string}`
-			: Paths<T[K], `${P}${K & string}.`> extends infer O
-			? T[K] extends Date | BigInt
-				? `${O & string}` | `${P}${K & string}`
-				: `${O & string}`
-			: never
-		: `${P}${K & string}`;
-}[keyof T];
+/**
+ * Compute all possible property combinations
+ */
+type normalTypes = PropertyKey | BigInt | Date | boolean | Array<unknown>;
+export type DocumentPaths<T, Cache extends string = ""> = T extends normalTypes
+	? Cache
+	: {
+			[P in keyof T]: P extends string
+				? Cache extends ""
+					? DocumentPaths<T[P], `${P}`>
+					: Cache | DocumentPaths<T[P], `${Cache}.${P}`>
+				: `${Cache}${P & string}`;
+	  }[keyof T];
 
 export type SelectorOperator =
 	| "$eq"
@@ -775,7 +777,7 @@ export type SelectorOperator =
 export type LogicalOperator = "$or" | "$and";
 
 export type SelectorFilter<T> = {
-	[K in PathsForFilter<T>]?: PathType<T, K> | { [P in SelectorOperator]?: PathType<T, K> };
+	[K in DocumentPaths<T>]?: PathType<T, K> | { [P in SelectorOperator]?: PathType<T, K> };
 };
 
 export type LogicalFilter<T> = {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -88,7 +88,7 @@ export const Utility = {
 	_getRandomInt(upperBound: number): number {
 		return Math.floor(Math.random() * upperBound);
 	},
-	readFieldString(readFields: ReadFields): string {
+	readFieldString<T>(readFields: ReadFields<T>): string {
 		const include = readFields.include?.reduce((acc, field) => ({ ...acc, [field]: true }), {});
 		const exclude = readFields.exclude?.reduce((acc, field) => ({ ...acc, [field]: false }), {});
 
@@ -499,8 +499,9 @@ export const Utility = {
 		return { ...defaults, ...options };
 	},
 
-	facetQueryToString(facets: FacetFieldsQuery): string {
-		const optionsMap = {};
+	facetQueryToString<T>(facets: FacetFieldsQuery<T>): string {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const optionsMap: any = {};
 		if (Array.isArray(facets)) {
 			for (const f of facets) {
 				optionsMap[f] = this.defaultFacetingOptions();
@@ -520,7 +521,7 @@ export const Utility = {
 		return this.objToJsonString(q);
 	},
 
-	_sortOrderingToString(ordering: SortOrder): string {
+	_sortOrderingToString<T>(ordering: SortOrder<T>): string {
 		if (typeof ordering === "undefined") {
 			return "[]";
 		}
@@ -575,7 +576,9 @@ export const Utility = {
 		}
 
 		if (query.sort !== undefined) {
-			searchRequest.setSort(Utility.stringToUint8Array(Utility._sortOrderingToString(query.sort)));
+			searchRequest.setSort(
+				Utility.stringToUint8Array(Utility._sortOrderingToString<T>(query.sort))
+			);
 		}
 
 		if (query.groupBy !== undefined) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- Added static binding for query constructors ( Search, Find & Update) 
- Refactored DocumentPaths type (the previous version was not able to flatten the objects which were defined as optional)


/claim #318
## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->


- Closes #318 

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [ ] Yes
- [x] No, and this is why: Because we have attached the Generics to those query constructs, the typescript compiler will throw errors.

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?

- [ ] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      and replace this text as `tigrisdata/tigris-docs#123`_
- [ ] No

### Checklist

- [x] `npm run build` - builds successfully
- [x] `npm run test` - tests passing
- [x] `npm run lint` - no lint errors

## [optional] Are there any post deployment tasks we need to perform?
