### PR TITLE
fix: Handle missing decorator for model

### DIFF
--- a/src/__tests__/tigris.search.spec.ts
+++ b/src/__tests__/tigris.search.spec.ts
@@ -63,6 +63,12 @@ describe("Search Indexing", () => {
 			const createPromise = tigris.createOrUpdateIndex("any other index", bookSchema);
 			await expect(createPromise).rejects.toThrow("Server error");
 		});
+		it("fails for not adding the TigrisSearchIndex decorator", async () => {
+			const createPromise = tigris.createOrUpdateIndex(BlogPostWithoutDecorator);
+			await expect(createPromise).rejects.toThrow(
+				"An attempt was made to retrieve an index with the name"
+			);
+		});
 	});
 
 	describe("getIndex", () => {
@@ -212,6 +218,20 @@ const bookSchema: TigrisIndexSchema<Book> = {
 
 @TigrisSearchIndex(SearchServiceFixtures.CreateIndex.Blog)
 class BlogPost {
+	@SearchField({ facet: true })
+	text: string;
+
+	@SearchField({ elements: TigrisDataTypes.STRING })
+	comments: Array<string>;
+
+	@SearchField()
+	author: string;
+
+	@SearchField({ sort: true })
+	createdAt: Date;
+}
+
+class BlogPostWithoutDecorator {
 	@SearchField({ facet: true })
 	text: string;
 

--- a/src/schema/decorated-schema-processor.ts
+++ b/src/schema/decorated-schema-processor.ts
@@ -40,6 +40,9 @@ export class DecoratedSchemaProcessor {
 
 	processIndex(cls: new () => TigrisIndexType): IndexSchema<typeof cls> {
 		const index = this.storage.getIndexByTarget(cls);
+		if (!index) {
+			return;
+		}
 		const schema = this.buildTigrisSchema(index.target, false);
 		return {
 			name: index.indexName,

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -53,6 +53,16 @@ export class Search {
 
 		if (mayBeClass && !schema) {
 			const generatedIndex = this.schemaProcessor.processIndex(mayBeClass);
+			if (!generatedIndex) {
+				return new Promise<SearchIndex<T>>((resolve, reject) => {
+					reject(
+						new Error(
+							`An attempt was made to retrieve an index with the name ${indexName} but there is no index defined with that name.` +
+								+"Please make sure an index has been defined using the 'TigrisSearchIndex' decorator."
+						)
+					);
+				});
+			}
 			schema = generatedIndex.schema as TigrisIndexSchema<T>;
 			// if indexName is not provided, use the one from model class
 			indexName = indexName ?? generatedIndex.name;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Solves #343. Return a more descriptive error message when the `@TigrisSearchIndex` decorator is not set. 
## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #343

- Closes #343

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why?_

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?

- [ ] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      and replace this text as `tigrisdata/tigris-docs#123`_
- [x] No

### Checklist

- [x] `npm run build` - builds successfully
- [x] `npm run test` - tests passing
- [x] `npm run lint` - no lint errors

## [optional] Are there any post deployment tasks we need to perform?

/claim #343 