### PR TITLE
fix: relax filter type checking

### DIFF
--- a/src/__tests__/tigris.filters.spec.ts
+++ b/src/__tests__/tigris.filters.spec.ts
@@ -46,6 +46,40 @@ describe("filters tests", () => {
 		);
 	});
 
+	it("filter with an array value on array field", () => {
+		const arrayFilter: Filter<IUser1> = {
+			tags: ["tag1"],
+		};
+		expect(Utility.filterToString(arrayFilter)).toBe('{"tags":["tag1"]}');
+	});
+
+	it("filter with a string value on array field", () => {
+		const arrayFilter: Filter<IUser1> = {
+			tags: "tag1",
+		};
+		expect(Utility.filterToString(arrayFilter)).toBe('{"tags":"tag1"}');
+	});
+
+	it("filter with an array value on array of objects", () => {
+		const arrayFilter: Filter<IUser1> = {
+			address: [
+				{
+					city: "city1",
+				},
+			],
+		};
+		expect(Utility.filterToString(arrayFilter)).toBe('{"address":[{"city":"city1"}]}');
+	});
+
+	it("filter with an object value on array of objects", () => {
+		const arrayFilter: Filter<IUser1> = {
+			address: {
+				city: "city1",
+			},
+		};
+		expect(Utility.filterToString(arrayFilter)).toBe('{"address":{"city":"city1"}}');
+	});
+
 	it("simplerSelectorWithinLogicalFilterTest", () => {
 		const filter1: Filter<IUser> = {
 			$and: [
@@ -285,6 +319,14 @@ export interface IUser extends TigrisCollectionType {
 	balance: number;
 }
 
+export class UserAddress {
+	street: string;
+	unit: string;
+	city: string;
+	state: string;
+	zipcode: number;
+}
+
 @TigrisCollection("user1")
 export class IUser1 {
 	@PrimaryKey({ order: 1 })
@@ -299,6 +341,10 @@ export class IUser1 {
 	createdAt: string;
 	@Field()
 	updatedAt: Date;
+	@Field({ elements: TigrisDataTypes.STRING })
+	tags: string[];
+	@Field({ elements: UserAddress })
+	address: UserAddress[];
 }
 
 export interface IUser2 extends TigrisCollectionType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -778,7 +778,11 @@ export type SelectorOperator =
 export type LogicalOperator = "$or" | "$and";
 
 export type SelectorFilter<T> = {
-	[K in DocumentPaths<T>]?: PathType<T, K> | { [P in SelectorOperator]?: PathType<T, K> };
+	[K in DocumentPaths<T>]?:
+		| PathType<T, K>
+		| { [P in SelectorOperator]?: PathType<T, K> }
+		| FieldTypes
+		| { [P in SelectorOperator]?: FieldTypes };
 };
 
 export type LogicalFilter<T> = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently, filters are strongly typed. This presents an issue for complex types like array, where we may want to do queries such as `contains` on array type fields.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why?_

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?

- [ ] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      and replace this text as `tigrisdata/tigris-docs#123`_
- [ ] No

### Checklist

- [ ] `npm run build` - builds successfully
- [ ] `npm run test` - tests passing
- [ ] `npm run lint` - no lint errors

## [optional] Are there any post deployment tasks we need to perform?
