### PR TITLE
chore: Improve error logging when project name in use does not exist on Tigris

### DIFF
--- a/src/__tests__/tigris.rpc.spec.ts
+++ b/src/__tests__/tigris.rpc.spec.ts
@@ -991,6 +991,7 @@ describe("rpc tests", () => {
 
 	describe("DB branching", () => {
 		const tigris = new Tigris(testConfig);
+		const mockedUtil = spy(Utility);
 
 		it("creates a new branch", async () => {
 			expect.hasAssertions();
@@ -1009,6 +1010,13 @@ describe("rpc tests", () => {
 			});
 
 			return expect(createResp).rejects.toBeDefined();
+		});
+
+		it("fails to create branch if project does not exist", async () => {
+			when(mockedUtil.branchNameFromEnv(anything())).thenReturn(Branch.NotFound);
+			const db = tigris.getDatabase();
+
+			return expect(db.createBranch(Branch.NotFound)).rejects.toThrow(Error);
 		});
 
 		it("deletes a branch successfully", async () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -382,9 +382,9 @@ export class DB {
 			this.grpcClient.createBranch(req, (error, response) => {
 				if (error) {
 					if (error.code === Status.UNKNOWN) {
-                        const error_message = `The project ${this.name} could not be found. Please ensure ${this.name} exists in your Tigris deployment or target Tigris region.`
-                        Log.error(error_message)
-                    }
+						const error_message = `The project ${this.name} could not be found. Please ensure ${this.name} exists in your Tigris deployment or target Tigris region.`;
+						Log.error(error_message);
+					}
 					reject(error);
 					return;
 				}

--- a/src/db.ts
+++ b/src/db.ts
@@ -381,7 +381,7 @@ export class DB {
 			const req = new ProtoCreateBranchRequest().setProject(this.name).setBranch(name);
 			this.grpcClient.createBranch(req, (error, response) => {
 				if (error) {
-					if (error.code === Status.UNKNOWN) {
+					if (error.code === Status.NOT_FOUND) {
 						const error_message = `The project ${this.name} could not be found. Please ensure ${this.name} exists in your Tigris deployment or target Tigris region.`;
 						Log.error(error_message);
 					}

--- a/src/db.ts
+++ b/src/db.ts
@@ -381,6 +381,10 @@ export class DB {
 			const req = new ProtoCreateBranchRequest().setProject(this.name).setBranch(name);
 			this.grpcClient.createBranch(req, (error, response) => {
 				if (error) {
+					if (error.code === Status.UNKNOWN) {
+                        const error_message = `The project ${this.name} could not be found. Please ensure ${this.name} exists in your Tigris deployment or target Tigris region.`
+                        Log.error(error_message)
+                    }
 					reject(error);
 					return;
 				}


### PR DESCRIPTION
## Background
Some calls to the server return useful error messages by default. A few operations do not.
The initializeBranch functionality for instance, explicitly handles similar errors and 
logs a useful error message when branch already exists.

Since any operation on a non-existing project will fail I explored the possibility of finding a "central"
location to log a useful error message. I didn't find any. My only thought was to modify the response 
returned by the "server"

In this PR I only modified the createBranch method to log a useful error message when project does not
exist. The same method is called when initializing branches so this change caters for both. 

Other methods (registerSchemas) where similar errors occur have useful error messages 
returned from the api at the moment.

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue  #377
- Closes  #377
- /claim #377

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: The changes do not affect existing functionality. It only introduces a useful error log.
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why?_

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?

- [ ] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      and replace this text as `tigrisdata/tigris-docs#123`_
- [x] No

### Checklist

- [x] `npm run build` - builds successfully
- [x] `npm run test` - tests passing
- [x] `npm run lint` - no lint errors

## [optional] Are there any post deployment tasks we need to perform?
/claim #377