### PR TITLE
fix: Wrap all RPC and Http requests behind a driver 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,5 +33,5 @@
 		"@typescript-eslint/quotes": ["error"],
 		"tsdoc/syntax": "error"
 	},
-	"ignorePatterns": ["src/__tests__/*", "dist/*"]
+	"ignorePatterns": ["src/__tests__/*", "dist/*", "src/http"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # Ignore artifacts:
 dist/
 src/proto/
+src/http/
 api/
 coverage/

--- a/jest.config.json
+++ b/jest.config.json
@@ -16,6 +16,7 @@
 		"src/decorators/*.ts",
 		"src/schema/**/*.ts",
 		"src/search/**/*.ts",
-		"src/utils/**/*.ts"
+		"src/utils/**/*.ts",
+		"!src/http/**"
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
 				"grpc_tools_node_protoc_ts": "^5.3.2",
 				"grpc-tools": "^1.12.4",
 				"jest": "^28.1.3",
+				"openapi-typescript-codegen": "^0.24.0",
 				"prettier": "2.7.1",
 				"ts-jest": "^28.0.8",
 				"ts-mockito": "^2.6.1",
@@ -55,6 +56,18 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@apidevtools/json-schema-ref-parser": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+			"integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+			"dev": true,
+			"dependencies": {
+				"@jsdevtools/ono": "^7.1.3",
+				"@types/json-schema": "^7.0.6",
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^4.1.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1409,6 +1422,12 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"node_modules/@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+			"dev": true
+		},
 		"node_modules/@mapbox/node-pre-gyp": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
@@ -2614,6 +2633,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/call-me-maybe": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+			"dev": true
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2820,6 +2845,15 @@
 			"dev": true,
 			"bin": {
 				"color-support": "bin.js"
+			}
+		},
+		"node_modules/commander": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/compare-func": {
@@ -6045,6 +6079,19 @@
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
+		},
+		"node_modules/json-schema-ref-parser": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+			"integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
+			"deprecated": "Please switch to @apidevtools/json-schema-ref-parser",
+			"dev": true,
+			"dependencies": {
+				"@apidevtools/json-schema-ref-parser": "9.0.9"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -9413,6 +9460,48 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/openapi-typescript-codegen": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.24.0.tgz",
+			"integrity": "sha512-rSt8t1XbMWhv6Db7GUI24NNli7FU5kzHLxcE8BpzgGWRdWyWt9IB2YoLyPahxNrVA7yOaVgnXPkrcTDRMQtJYg==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^6.3.0",
+				"commander": "^10.0.0",
+				"fs-extra": "^11.1.1",
+				"handlebars": "^4.7.7",
+				"json-schema-ref-parser": "^9.0.9"
+			},
+			"bin": {
+				"openapi": "bin/index.js"
+			}
+		},
+		"node_modules/openapi-typescript-codegen/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/openapi-typescript-codegen/node_modules/fs-extra": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+			"integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -11501,6 +11590,18 @@
 				"@jridgewell/trace-mapping": "^0.3.9"
 			}
 		},
+		"@apidevtools/json-schema-ref-parser": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+			"integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+			"dev": true,
+			"requires": {
+				"@jsdevtools/ono": "^7.1.3",
+				"@types/json-schema": "^7.0.6",
+				"call-me-maybe": "^1.0.1",
+				"js-yaml": "^4.1.0"
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -12546,6 +12647,12 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"@jsdevtools/ono": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+			"integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+			"dev": true
+		},
 		"@mapbox/node-pre-gyp": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
@@ -13480,6 +13587,12 @@
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true
 		},
+		"call-me-maybe": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+			"dev": true
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -13627,6 +13740,12 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"dev": true
+		},
+		"commander": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
 			"dev": true
 		},
 		"compare-func": {
@@ -16096,6 +16215,15 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"dev": true
 		},
+		"json-schema-ref-parser": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+			"integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
+			"dev": true,
+			"requires": {
+				"@apidevtools/json-schema-ref-parser": "9.0.9"
+			}
+		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -18506,6 +18634,38 @@
 			"dev": true,
 			"requires": {
 				"mimic-fn": "^2.1.0"
+			}
+		},
+		"openapi-typescript-codegen": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.24.0.tgz",
+			"integrity": "sha512-rSt8t1XbMWhv6Db7GUI24NNli7FU5kzHLxcE8BpzgGWRdWyWt9IB2YoLyPahxNrVA7yOaVgnXPkrcTDRMQtJYg==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^6.3.0",
+				"commander": "^10.0.0",
+				"fs-extra": "^11.1.1",
+				"handlebars": "^4.7.7",
+				"json-schema-ref-parser": "^9.0.9"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+					"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+					"dev": true
+				},
+				"fs-extra": {
+					"version": "11.1.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+					"integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				}
 			}
 		},
 		"optionator": {

--- a/package.json
+++ b/package.json
@@ -89,16 +89,17 @@
 		"@types/json-bigint": "^1.0.1",
 		"@typescript-eslint/eslint-plugin": "^5.35.1",
 		"@typescript-eslint/parser": "^5.35.1",
-		"eslint-plugin-tsdoc": "0.2.17",
 		"copyfiles": "^2.4.1",
 		"eslint": "^8.22.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-functional": "^4.2.2",
+		"eslint-plugin-tsdoc": "0.2.17",
 		"eslint-plugin-unicorn": "^43.0.2",
 		"eslint-plugin-unused-imports": "^2.0.0",
 		"grpc_tools_node_protoc_ts": "^5.3.2",
 		"grpc-tools": "^1.12.4",
 		"jest": "^28.1.3",
+		"openapi-typescript-codegen": "^0.24.0",
 		"prettier": "2.7.1",
 		"ts-jest": "^28.0.8",
 		"ts-mockito": "^2.6.1",
@@ -108,11 +109,11 @@
 	},
 	"dependencies": {
 		"@grpc/grpc-js": "^1.8.14",
+		"app-root-path": "^3.1.0",
 		"chalk": "4.1.2",
 		"dotenv": "^16.0.3",
 		"google-protobuf": "^3.21.0",
 		"json-bigint": "github:sidorares/json-bigint",
-		"reflect-metadata": "^0.1.13",
-		"app-root-path": "^3.1.0"
+		"reflect-metadata": "^0.1.13"
 	}
 }

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -30,6 +30,8 @@ const EXPECTED_EXPORTS = [
 	"DocStatus",
 	"DropCollectionResponse",
 	"FacetCount",
+	// TODO REMOVE LATER
+	"FacetCountDistribution",
 	"FacetStats",
 	"Field",
 	"FindQueryOptions",
@@ -48,7 +50,8 @@ const EXPECTED_EXPORTS = [
 	"SearchMeta",
 	"SearchResult",
 	"ServerMetadata",
-	"Session",
+	// TODO this is a type now
+	// "Session",
 	"Status",
 	"TextMatchInfo",
 	"Tigris",

--- a/src/__tests__/search/search.spec.ts
+++ b/src/__tests__/search/search.spec.ts
@@ -5,21 +5,27 @@ import {
 	TigrisIndexSchema,
 	TigrisSearchIndex,
 } from "../../search";
-import { capture, instance, mock, reset, spy } from "ts-mockito";
+import { capture, instance, mock, reset } from "ts-mockito";
 import { SearchClient as ProtoSearchClient } from "../../proto/server/v1/search_grpc_pb";
 import { CreateOrUpdateIndexResponse as ProtoCreateIndexResponse } from "../../proto/server/v1/search_pb";
 import { Utility } from "../../utility";
 import { TigrisDataTypes } from "../../types";
 import { Status as ProtoStatus } from "@grpc/grpc-js/build/src/constants";
 import { ServiceError } from "@grpc/grpc-js";
+import { Search as SearchGrpc } from "../../driver/grpc/search";
+import { TigrisClient } from "../../proto/server/v1/api_grpc_pb";
 
 describe("Search", () => {
 	let target: Search;
 	let mockClient: ProtoSearchClient;
+	const config = { projectName: "test_project", serverUrl: "http://127.0.0.1" };
 
 	beforeEach(() => {
 		mockClient = mock(ProtoSearchClient);
-		target = new Search(instance(mockClient), { projectName: "test_project" });
+		let s = new SearchGrpc(config, undefined);
+		s.client = instance(mockClient);
+		s.tigrisClient = instance(mock(TigrisClient));
+		target = new Search(s, config);
 	});
 
 	afterEach(() => {

--- a/src/__tests__/search/search.spec.ts
+++ b/src/__tests__/search/search.spec.ts
@@ -22,7 +22,7 @@ describe("Search", () => {
 
 	beforeEach(() => {
 		mockClient = mock(ProtoSearchClient);
-		let s = new SearchGrpc(config, undefined);
+		let s = new SearchGrpc(config, undefined, {});
 		s.client = instance(mockClient);
 		s.tigrisClient = instance(mock(TigrisClient));
 		target = new Search(s, config);

--- a/src/__tests__/tigris.tokensupplier.spec.ts
+++ b/src/__tests__/tigris.tokensupplier.spec.ts
@@ -1,0 +1,35 @@
+import { TokenSupplier } from "../tokensupplier";
+import { mock, when, instance } from "ts-mockito";
+import Driver from "../driver/driver";
+
+describe("Token supplier", () => {
+	const config = {
+		clientId: "123",
+		clientSecret: "123",
+	};
+	it("should refresh if undefined", () => {
+		const driver = mock<Driver>();
+		const supplier = new TokenSupplier(config, driver);
+
+		expect(supplier.shouldRefresh()).toBeTruthy();
+	});
+
+	it("should refresh if old date", () => {
+		const driver = mock<Driver>();
+		const supplier = new TokenSupplier(config, driver);
+		//@ts-ignore
+		supplier.nextRefreshDate = new Date("2023-04-04T03:24:00");
+		expect(supplier.shouldRefresh()).toBeTruthy();
+	});
+
+	it("processes new token", async () => {
+		const accessToken = "0.NTAwMA==";
+		const driver = mock<Driver>();
+		when(driver.getAccessToken(config.clientId, config.clientSecret)).thenReturn(
+			Promise.resolve(accessToken)
+		);
+		const supplier = new TokenSupplier(config, instance(driver));
+		const res = await supplier.getAccessToken();
+		expect(res).toEqual(accessToken);
+	});
+});

--- a/src/driver/driver.ts
+++ b/src/driver/driver.ts
@@ -1,0 +1,169 @@
+import {
+	DocStatus,
+	IndexInfo,
+	IndexedDoc,
+	SearchCursor,
+	SearchQuery,
+	SearchResult,
+} from "../search";
+import { CacheKeysCursor, GrpcCursor } from "./grpc/consumables/cursor";
+import {
+	CacheDelResponse,
+	CacheGetResponse,
+	CacheSetOptions,
+	CacheSetResponse,
+	DeleteCacheResponse,
+	ListCachesResponse,
+	CacheGetSetResponse,
+	ServerMetadata,
+	CollectionOptions,
+	CollectionInfo,
+	DropCollectionResponse,
+	DatabaseDescription,
+	TransactionOptions,
+	CreateBranchResponse,
+	DeleteBranchResponse,
+	CollectionDescription,
+	TigrisCollectionType,
+	UpdateQuery,
+	UpdateResponse,
+	DeleteQuery,
+	DeleteResponse,
+	FindQuery,
+	Filter,
+	ExplainResponse,
+	Session,
+} from "../types";
+
+export default interface Driver {
+	database(): DatabaseDriver;
+	collection<T>(): CollectionDriver<T>;
+	search(): SearchDriver;
+	cache(): CacheDriver;
+	observability(): ObservabilityDriver;
+
+	getAccessToken(clientId: string, clientSecret: string): Promise<string>;
+	health(): Promise<string>;
+}
+
+export interface CacheDriver {
+	createCache(name: string): Promise<void>;
+	deleteCache(name: string): Promise<DeleteCacheResponse>;
+	listCaches(): Promise<ListCachesResponse>;
+	get(cacheName: string, key: string): Promise<CacheGetResponse>;
+	getSet(
+		cacheName: string,
+		key: string,
+		value: string | number | boolean | object
+	): Promise<CacheGetSetResponse>;
+	del(cacheName: string, key: string): Promise<CacheDelResponse>;
+	keys(cacheName: string, pattern?: string): CacheKeysCursor;
+	set(
+		cacheName: string,
+		key: string,
+		value: string | number | boolean | object,
+		options?: CacheSetOptions
+	): Promise<CacheSetResponse>;
+}
+
+export interface ObservabilityDriver {
+	getInfo(): Promise<ServerMetadata>;
+}
+
+export interface SearchDriver {
+	createOrUpdateIndex(index: string, schema: Uint8Array): Promise<string>;
+	listIndexes(): Promise<IndexInfo[]>;
+	deleteIndex(name: string): Promise<string>;
+
+	createMany(name: string, docs: Uint8Array[]): Promise<DocStatus[]>;
+	createOrReplaceMany(name: string, docs: Uint8Array[]): Promise<DocStatus[]>;
+	deleteMany(name: string, ids: string[]): Promise<DocStatus[]>;
+	deleteByQuery(name: string, filter: Uint8Array): Promise<number>;
+	getMany<T>(name: string, ids: string[]): Promise<IndexedDoc<T>[]>;
+	updateMany(name: string, docs: Uint8Array[]): Promise<DocStatus[]>;
+	searchCollection<T>(
+		db: string,
+		branch: string,
+		collectionName: string,
+		query: SearchQuery<T>,
+		page?: number
+	): SearchCursor<T> | Promise<SearchResult<T>>;
+	search<T>(
+		name: string,
+		query: SearchQuery<T>,
+		page?: number
+	): SearchCursor<T> | Promise<SearchResult<T>>;
+}
+
+export interface DatabaseDriver {
+	createOrUpdateCollection(
+		project: string,
+		branch: string,
+		coll: string,
+		onlyCreate: false,
+		schema: string
+	): Promise<void>;
+
+	listCollections(
+		projectName: string,
+		branch: string,
+		options?: CollectionOptions
+	): Promise<Array<CollectionInfo>>;
+
+	dropCollection(
+		project: string,
+		branch: string,
+		collection: string
+	): Promise<DropCollectionResponse>;
+
+	describe(name: string, branch: string): Promise<DatabaseDescription>;
+	beginTransaction(name: string, branch: string, _options?: TransactionOptions): Promise<Session>;
+	createBranch(name: string, branch: string): Promise<CreateBranchResponse>;
+	deleteBranch(name: string, branch: string): Promise<DeleteBranchResponse>;
+}
+
+export interface CollectionDriver<T extends TigrisCollectionType> {
+	describe(db: string, branch: string, coll: string): Promise<CollectionDescription>;
+
+	insertMany(
+		db: string,
+		branch: string,
+		coll: string,
+		createdAtNames: string[],
+		docs: T[],
+		tx?: Session
+	): Promise<T[]>;
+	insertOrReplaceMany(
+		db: string,
+		branch: string,
+		coll: string,
+		docs: T[],
+		tx?: Session
+	): Promise<T[]>;
+
+	updateMany(
+		db: string,
+		branch: string,
+		coll: string,
+		query: UpdateQuery<T>,
+		tx?: Session
+	): Promise<UpdateResponse>;
+
+	deleteMany(
+		db: string,
+		branch: string,
+		coll: string,
+		query: DeleteQuery<T>,
+		tx?: Session
+	): Promise<DeleteResponse>;
+
+	findMany(
+		db: string,
+		branch: string,
+		coll: string,
+		query: FindQuery<T>,
+		tx?: Session
+	): GrpcCursor<T>;
+	explain(db: string, branch: string, coll: string, query: FindQuery<T>): Promise<ExplainResponse>;
+	count(db: string, branch: string, coll: string, filter?: Filter<T>): Promise<number>;
+}

--- a/src/driver/grpc/cache.ts
+++ b/src/driver/grpc/cache.ts
@@ -1,0 +1,197 @@
+import { CacheDriver } from "../driver";
+import { Utility } from "../../utility";
+import { ChannelCredentials } from "@grpc/grpc-js";
+import {
+	DelRequest as ProtoDelRequest,
+	GetRequest as ProtoGetRequest,
+	GetSetRequest as ProtoGetSetRequest,
+	KeysRequest as ProtoKeysRequest,
+	SetRequest as ProtoSetRequest,
+} from "../../proto/server/v1/cache_pb";
+import {
+	CreateCacheRequest as ProtoCreateCacheRequest,
+	DeleteCacheRequest as ProtoDeleteCacheRequest,
+	ListCachesRequest as ProtoListCachesRequest,
+} from "../../proto/server/v1/cache_pb";
+import { TigrisClientConfig } from "../../tigris";
+import { CacheClient } from "../../proto/server/v1/cache_grpc_pb";
+import { Status } from "@grpc/grpc-js/build/src/constants";
+import {
+	CacheDelResponse,
+	CacheGetResponse,
+	CacheGetSetResponse,
+	CacheMetadata,
+	CacheSetOptions,
+	CacheSetResponse,
+	DeleteCacheResponse,
+	ListCachesResponse,
+} from "../../types";
+import { CacheKeysCursor, CacheKeysCursorInitializer } from "./consumables/cursor";
+
+export class Cache implements CacheDriver {
+	cacheClient: CacheClient;
+	config: TigrisClientConfig;
+	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials) {
+		this.config = config;
+		this.cacheClient = new CacheClient(config.serverUrl, channelCredentials);
+	}
+	get(cacheName: string, key: string): Promise<CacheGetResponse> {
+		return new Promise<CacheGetResponse>((resolve, reject) => {
+			this.cacheClient.get(
+				new ProtoGetRequest().setProject(this.config.projectName).setName(cacheName).setKey(key),
+				(error, response) => {
+					if (error) {
+						reject(error);
+					} else {
+						resolve(
+							new CacheGetResponse(
+								Utility._base64DecodeToObject(response.getValue_asB64(), this.config)
+							)
+						);
+					}
+				}
+			);
+		});
+	}
+
+	del(cacheName: string, key: string): Promise<CacheDelResponse> {
+		return new Promise<CacheDelResponse>((resolve, reject) => {
+			this.cacheClient.del(
+				new ProtoDelRequest().setProject(this.config.projectName).setName(cacheName).setKey(key),
+				(error, response) => {
+					if (error) {
+						reject(error);
+					} else {
+						resolve(new CacheDelResponse(response.getStatus(), response.getMessage()));
+					}
+				}
+			);
+		});
+	}
+
+	// TODO: Fix
+	keys(cacheName: string, pattern?: string): CacheKeysCursor {
+		const req = new ProtoKeysRequest().setProject(this.config.projectName).setName(cacheName);
+		if (pattern !== undefined) {
+			req.setPattern(pattern);
+		}
+		this.cacheClient.keys(req);
+		const initializer = new CacheKeysCursorInitializer(this.cacheClient, req);
+		return new CacheKeysCursor(initializer);
+	}
+
+	getSet(
+		cacheName: string,
+		key: string,
+		value: string | number | boolean | object
+	): Promise<CacheGetSetResponse> {
+		return new Promise<CacheGetSetResponse>((resolve, reject) => {
+			const req = new ProtoGetSetRequest()
+				.setProject(this.config.projectName)
+				.setName(cacheName)
+				.setKey(key)
+				.setValue(new TextEncoder().encode(Utility.objToJsonString(value as object)));
+
+			this.cacheClient.getSet(req, (error, response) => {
+				if (error) {
+					reject(error);
+				} else {
+					if (response.getOldValue() !== undefined && response.getOldValue_asU8().length > 0) {
+						resolve(
+							new CacheGetSetResponse(
+								response.getMessage(),
+								Utility._base64DecodeToObject(response.getOldValue_asB64(), this.config)
+							)
+						);
+					} else {
+						resolve(new CacheGetSetResponse(response.getMessage()));
+					}
+				}
+			});
+		});
+	}
+
+	set(
+		cacheName: string,
+		key: string,
+		value: string | number | boolean | object,
+		options?: CacheSetOptions
+	): Promise<CacheSetResponse> {
+		return new Promise<CacheSetResponse>((resolve, reject) => {
+			const req = new ProtoSetRequest()
+				.setProject(this.config.projectName)
+				.setName(cacheName)
+				.setKey(key)
+				.setValue(new TextEncoder().encode(Utility.objToJsonString(value as object)));
+
+			if (options !== undefined && options.ex !== undefined) {
+				req.setEx(options.ex);
+			}
+			if (options !== undefined && options.px !== undefined) {
+				req.setPx(options.px);
+			}
+			if (options !== undefined && options.nx !== undefined) {
+				req.setNx(options.nx);
+			}
+			if (options !== undefined && options.xx !== undefined) {
+				req.setXx(options.xx);
+			}
+
+			this.cacheClient.set(req, (error, response) => {
+				if (error) {
+					reject(error);
+				} else {
+					resolve(new CacheSetResponse(response.getMessage()));
+				}
+			});
+		});
+	}
+
+	createCache(name: string): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			this.cacheClient.createCache(
+				new ProtoCreateCacheRequest().setProject(this.config.projectName).setName(name),
+				(error) => {
+					if (error && error.code != Status.ALREADY_EXISTS) {
+						reject(error);
+					} else {
+						resolve();
+					}
+				}
+			);
+		});
+	}
+
+	deleteCache(name: string): Promise<DeleteCacheResponse> {
+		return new Promise<DeleteCacheResponse>((resolve, reject) => {
+			this.cacheClient.deleteCache(
+				new ProtoDeleteCacheRequest().setProject(this.config.projectName).setName(name),
+				(error, response) => {
+					if (error) {
+						reject(error);
+					} else {
+						resolve(new DeleteCacheResponse(response.getMessage()));
+					}
+				}
+			);
+		});
+	}
+
+	listCaches(): Promise<ListCachesResponse> {
+		return new Promise<ListCachesResponse>((resolve, reject) => {
+			this.cacheClient.listCaches(
+				new ProtoListCachesRequest().setProject(this.config.projectName),
+				(error, response) => {
+					if (error) {
+						reject(error);
+					} else {
+						const cachesMetadata: CacheMetadata[] = new Array<CacheMetadata>();
+						for (const value of response.getCachesList())
+							cachesMetadata.push(new CacheMetadata(value.getName()));
+						resolve(new ListCachesResponse(cachesMetadata));
+					}
+				}
+			);
+		});
+	}
+}

--- a/src/driver/grpc/cache.ts
+++ b/src/driver/grpc/cache.ts
@@ -1,6 +1,6 @@
 import { CacheDriver } from "../driver";
 import { Utility } from "../../utility";
-import { ChannelCredentials } from "@grpc/grpc-js";
+import { ChannelCredentials, ClientOptions } from "@grpc/grpc-js";
 import {
 	DelRequest as ProtoDelRequest,
 	GetRequest as ProtoGetRequest,
@@ -31,9 +31,13 @@ import { CacheKeysCursor, CacheKeysCursorInitializer } from "./consumables/curso
 export class Cache implements CacheDriver {
 	cacheClient: CacheClient;
 	config: TigrisClientConfig;
-	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials) {
+	constructor(
+		config: TigrisClientConfig,
+		channelCredentials: ChannelCredentials,
+		opts: ClientOptions
+	) {
 		this.config = config;
-		this.cacheClient = new CacheClient(config.serverUrl, channelCredentials);
+		this.cacheClient = new CacheClient(config.serverUrl, channelCredentials, opts);
 	}
 	get(cacheName: string, key: string): Promise<CacheGetResponse> {
 		return new Promise<CacheGetResponse>((resolve, reject) => {

--- a/src/driver/grpc/collection.ts
+++ b/src/driver/grpc/collection.ts
@@ -2,7 +2,7 @@ import { CollectionDriver } from "../driver";
 import { Utility } from "../../utility";
 import { TigrisClient } from "../../proto/server/v1/api_grpc_pb";
 import * as grpc from "@grpc/grpc-js";
-import { ChannelCredentials } from "@grpc/grpc-js";
+import { ChannelCredentials, ClientOptions } from "@grpc/grpc-js";
 import {
 	DeleteRequest as ProtoDeleteRequest,
 	InsertRequest as ProtoInsertRequest,
@@ -36,9 +36,13 @@ import { GrpcSession } from "./session";
 export class GrpcCollectionDriver<T extends TigrisCollectionType> implements CollectionDriver<T> {
 	client: TigrisClient;
 	config: TigrisClientConfig;
-	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials) {
+	constructor(
+		config: TigrisClientConfig,
+		channelCredentials: ChannelCredentials,
+		opts: ClientOptions
+	) {
 		this.config = config;
-		this.client = new TigrisClient(config.serverUrl, channelCredentials);
+		this.client = new TigrisClient(config.serverUrl, channelCredentials, opts);
 	}
 
 	describe(db: string, branch: string, coll: string): Promise<CollectionDescription> {

--- a/src/driver/grpc/collection.ts
+++ b/src/driver/grpc/collection.ts
@@ -1,0 +1,335 @@
+import { CollectionDriver } from "../driver";
+import { Utility } from "../../utility";
+import { TigrisClient } from "../../proto/server/v1/api_grpc_pb";
+import * as grpc from "@grpc/grpc-js";
+import { ChannelCredentials } from "@grpc/grpc-js";
+import {
+	DeleteRequest as ProtoDeleteRequest,
+	InsertRequest as ProtoInsertRequest,
+	ReadRequest as ProtoReadRequest,
+	UpdateRequest as ProtoUpdateRequest,
+	CountRequest as ProtoCountRequest,
+	DescribeCollectionRequest as ProtoDescribeCollectionRequest,
+	InsertResponse as ProtoInsertResponse,
+	ReplaceResponse as ProtoReplaceResponse,
+	ReplaceRequest as ProtoReplaceRequest,
+} from "../../proto/server/v1/api_pb";
+import { TigrisClientConfig } from "../../tigris";
+import {
+	CollectionDescription,
+	DMLMetadata,
+	DeleteQuery,
+	DeleteResponse,
+	ExplainResponse,
+	Filter,
+	FindQuery,
+	IndexDescription,
+	ReadType,
+	Session,
+	TigrisCollectionType,
+	UpdateQuery,
+	UpdateResponse,
+} from "../../types";
+import { GrpcCursor, ReadCursorInitializer } from "./consumables/cursor";
+import { GrpcSession } from "./session";
+
+export class GrpcCollectionDriver<T extends TigrisCollectionType> implements CollectionDriver<T> {
+	client: TigrisClient;
+	config: TigrisClientConfig;
+	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials) {
+		this.config = config;
+		this.client = new TigrisClient(config.serverUrl, channelCredentials);
+	}
+
+	describe(db: string, branch: string, coll: string): Promise<CollectionDescription> {
+		return new Promise((resolve, reject) => {
+			const req = new ProtoDescribeCollectionRequest()
+				.setProject(db)
+				.setBranch(branch)
+				.setCollection(coll);
+
+			this.client.describeCollection(req, (error, resp) => {
+				if (error) {
+					return reject(error);
+				}
+				const schema = Buffer.from(resp.getSchema_asB64(), "base64").toString();
+				const desc = new CollectionDescription(
+					coll,
+					resp.getMetadata(),
+					schema,
+					resp.toObject().indexesList as IndexDescription[]
+				);
+
+				resolve(desc);
+			});
+		});
+	}
+
+	insertMany(
+		db: string,
+		branch: string,
+		coll: string,
+		createdAtNames: string[],
+		docs: T[],
+		tx?: Session
+	): Promise<T[]> {
+		const encoder = new TextEncoder();
+		return new Promise<T[]>((resolve, reject) => {
+			const docsArray: Array<Uint8Array | string> = docs.map((doc) =>
+				encoder.encode(Utility.objToJsonString(doc))
+			);
+
+			const protoRequest = new ProtoInsertRequest()
+				.setProject(db)
+				.setBranch(branch)
+				.setCollection(coll)
+				.setDocumentsList(docsArray);
+
+			this.client.insert(
+				protoRequest,
+				Utility.txToMetadata(tx as GrpcSession),
+				(error: grpc.ServiceError, response: ProtoInsertResponse): void => {
+					if (error) {
+						reject(error);
+					} else {
+						let clonedDocs: Array<T>;
+						clonedDocs = this.setDocsMetadata(docs, response.getKeysList_asU8());
+						if (response.getMetadata().hasCreatedAt()) {
+							const createdAt = new Date(
+								response.getMetadata()?.getCreatedAt()?.getSeconds() * 1000
+							);
+							clonedDocs = this.setCreatedAtForDocsIfNotExists(
+								clonedDocs,
+								createdAt,
+								createdAtNames
+							);
+						}
+						resolve(clonedDocs);
+					}
+				}
+			);
+		});
+	}
+
+	insertOrReplaceMany(
+		db: string,
+		branch: string,
+		coll: string,
+		docs: T[],
+		tx?: Session
+	): Promise<T[]> {
+		return new Promise<Array<T>>((resolve, reject) => {
+			const docsArray: Array<Uint8Array | string> = docs.map((doc) =>
+				new TextEncoder().encode(Utility.objToJsonString(doc))
+			);
+			const protoRequest = new ProtoReplaceRequest()
+				.setProject(db)
+				.setBranch(branch)
+				.setCollection(coll)
+				.setDocumentsList(docsArray);
+
+			this.client.replace(
+				protoRequest,
+				Utility.txToMetadata(tx as GrpcSession),
+				(error: grpc.ServiceError, response: ProtoReplaceResponse): void => {
+					if (error) {
+						reject(error);
+					} else {
+						const clonedDocs = this.setDocsMetadata(docs, response.getKeysList_asU8());
+						resolve(clonedDocs);
+					}
+				}
+			);
+		});
+	}
+
+	updateMany(
+		db: string,
+		branch: string,
+		coll: string,
+		query: UpdateQuery<T>,
+		tx?: Session
+	): Promise<UpdateResponse> {
+		return new Promise<UpdateResponse>((resolve, reject) => {
+			const updateRequest = new ProtoUpdateRequest()
+				.setProject(db)
+				.setBranch(branch)
+				.setCollection(coll)
+				.setFilter(Utility.stringToUint8Array(Utility.filterToString(query.filter)))
+				.setFields(Utility.stringToUint8Array(Utility.updateFieldsString(query.fields)));
+
+			if (query.options !== undefined) {
+				updateRequest.setOptions(
+					Utility._updateRequestOptionsToProtoUpdateRequestOptions(query.options)
+				);
+			}
+
+			this.client.update(
+				updateRequest,
+				Utility.txToMetadata(tx as GrpcSession),
+				(error, response) => {
+					if (error) {
+						reject(error);
+					} else {
+						const metadata: DMLMetadata = new DMLMetadata(
+							response.getMetadata().getCreatedAt(),
+							response.getMetadata().getUpdatedAt()
+						);
+						resolve(new UpdateResponse(response.getModifiedCount(), metadata));
+					}
+				}
+			);
+		});
+	}
+
+	deleteMany(
+		db: string,
+		branch: string,
+		coll: string,
+		query: DeleteQuery<T>,
+		tx?: Session
+	): Promise<DeleteResponse> {
+		return new Promise<DeleteResponse>((resolve, reject) => {
+			const deleteRequest = new ProtoDeleteRequest()
+				.setProject(db)
+				.setBranch(branch)
+				.setCollection(coll)
+				.setFilter(Utility.stringToUint8Array(Utility.filterToString(query.filter)));
+
+			if (query.options) {
+				deleteRequest.setOptions(
+					Utility._deleteRequestOptionsToProtoDeleteRequestOptions(query.options)
+				);
+			}
+
+			this.client.delete(
+				deleteRequest,
+				Utility.txToMetadata(tx as GrpcSession),
+				(error, response) => {
+					if (error) {
+						reject(error);
+					} else {
+						const metadata: DMLMetadata = new DMLMetadata(
+							response.getMetadata().getCreatedAt(),
+							response.getMetadata().getUpdatedAt()
+						);
+						resolve(new DeleteResponse(metadata));
+					}
+				}
+			);
+		});
+	}
+
+	findMany(
+		db: string,
+		branch: string,
+		coll: string,
+		query: FindQuery<T>,
+		tx?: Session
+	): GrpcCursor<T> {
+		const readRequest = new ProtoReadRequest()
+			.setProject(db)
+			.setBranch(branch)
+			.setCollection(coll)
+			.setFilter(Utility.stringToUint8Array(Utility.filterToString(query.filter)));
+
+		if (query.readFields) {
+			readRequest.setFields(
+				Utility.stringToUint8Array(Utility.readFieldString<T>(query.readFields))
+			);
+		}
+
+		if (query.sort) {
+			readRequest.setSort(Utility.stringToUint8Array(Utility._sortOrderingToString<T>(query.sort)));
+		}
+
+		if (query.options) {
+			readRequest.setOptions(Utility._readRequestOptionsToProtoReadRequestOptions(query.options));
+		}
+
+		const initializer = new ReadCursorInitializer(this.client, readRequest, tx as GrpcSession);
+		return new GrpcCursor<T>(initializer, this.config);
+	}
+
+	explain(db: string, branch: string, coll: string, query: FindQuery<T>): Promise<ExplainResponse> {
+		const readRequest = new ProtoReadRequest()
+			.setProject(db)
+			.setBranch(branch)
+			.setCollection(coll)
+			.setFilter(Utility.stringToUint8Array(Utility.filterToString(query.filter)));
+		return new Promise((resolve, reject) => {
+			this.client.explain(readRequest, (err, resp) => {
+				if (err) {
+					return reject(err);
+				}
+
+				const explainResp = resp.toObject();
+				explainResp.readType =
+					resp.getReadType() === "secondary index"
+						? ("secondary index" as ReadType)
+						: ("primary index" as ReadType);
+
+				resolve(explainResp as ExplainResponse);
+			});
+		});
+	}
+
+	count(db: string, branch: string, coll: string, filter?: Filter<T>): Promise<number> {
+		if (!filter) {
+			filter = {};
+		}
+		const countRequest = new ProtoCountRequest()
+			.setProject(db)
+			.setCollection(coll)
+			.setBranch(branch)
+			.setFilter(Utility.stringToUint8Array(Utility.filterToString(filter)));
+
+		return new Promise((resolve, reject) => {
+			this.client.count(countRequest, (err, response) => {
+				if (err) {
+					return reject(err);
+				}
+				resolve(response.getCount());
+			});
+		});
+	}
+
+	private setDocsMetadata(docs: Array<T>, keys: Array<Uint8Array>): Array<T> {
+		let docIndex = 0;
+		const clonedDocs: T[] = Object.assign([], docs);
+
+		for (const value of keys) {
+			const keyValueJsonObj: object = Utility.jsonStringToObj(
+				Utility.uint8ArrayToString(value),
+				this.config
+			);
+			for (const fieldName of Object.keys(keyValueJsonObj)) {
+				Reflect.set(clonedDocs[docIndex], fieldName, keyValueJsonObj[fieldName]);
+			}
+			docIndex++;
+		}
+
+		return clonedDocs;
+	}
+
+	// TODO this should not be here
+	private setCreatedAtForDocsIfNotExists(
+		docs: Array<T>,
+		createdAt: Date,
+		collectionCreatedAtFieldNames: string[]
+	): Array<T> {
+		const clonedDocs: T[] = Object.assign([], docs);
+		let docIndex = 0;
+
+		for (const doc of docs) {
+			collectionCreatedAtFieldNames.map((fieldName) => {
+				if (!Reflect.has(doc, fieldName)) {
+					Reflect.set(clonedDocs[docIndex], fieldName, createdAt);
+				}
+			});
+			docIndex++;
+		}
+
+		return clonedDocs;
+	}
+}

--- a/src/driver/grpc/consumables/cursor.ts
+++ b/src/driver/grpc/consumables/cursor.ts
@@ -1,20 +1,20 @@
-import { IterableStream, Initializer } from "./iterable-stream";
-import { ReadRequest, ReadResponse } from "../proto/server/v1/api_pb";
-import { TigrisClient } from "../proto/server/v1/api_grpc_pb";
-import { Session } from "../session";
-import { Utility } from "../utility";
+import { GrpcIterableStream, Initializer } from "./iterable-stream";
+import { ReadRequest, ReadResponse } from "../../../proto/server/v1/api_pb";
+import { TigrisClient } from "../../../proto/server/v1/api_grpc_pb";
+import { GrpcSession } from "../session";
+import { Utility } from "../../../utility";
 import { ClientReadableStream } from "@grpc/grpc-js";
-import { TigrisClientConfig } from "../tigris";
-import { KeysRequest, KeysResponse } from "../proto/server/v1/cache_pb";
-import { CacheClient } from "../proto/server/v1/cache_grpc_pb";
+import { TigrisClientConfig } from "../../../tigris";
+import { KeysRequest, KeysResponse } from "../../../proto/server/v1/cache_pb";
+import { CacheClient } from "../../../proto/server/v1/cache_grpc_pb";
 
 /** @internal */
 export class ReadCursorInitializer implements Initializer<ReadResponse> {
 	private readonly _client: TigrisClient;
 	private readonly _request: ReadRequest;
-	private readonly _session: Session;
+	private readonly _session: GrpcSession;
 
-	constructor(client: TigrisClient, request: ReadRequest, tx: Session) {
+	constructor(client: TigrisClient, request: ReadRequest, tx: GrpcSession) {
 		this._client = client;
 		this._request = request;
 		this._session = tx;
@@ -43,7 +43,7 @@ export class CacheKeysCursorInitializer implements Initializer<KeysResponse> {
 /**
  * Cursor to supplement find() queries
  */
-export class Cursor<T> extends IterableStream<T, ReadResponse> {
+export class GrpcCursor<T> extends GrpcIterableStream<T, ReadResponse> {
 	/** @internal */
 	private readonly _config: TigrisClientConfig;
 
@@ -61,7 +61,7 @@ export class Cursor<T> extends IterableStream<T, ReadResponse> {
 /**
  * Cursor to supplement keys() call for cache
  */
-export class CacheKeysCursor extends IterableStream<string[], KeysResponse> {
+export class CacheKeysCursor extends GrpcIterableStream<string[], KeysResponse> {
 	/** @internal */
 
 	constructor(initializer: CacheKeysCursorInitializer) {

--- a/src/driver/grpc/consumables/iterable-stream.ts
+++ b/src/driver/grpc/consumables/iterable-stream.ts
@@ -1,7 +1,8 @@
 import * as proto from "google-protobuf";
 import { ClientReadableStream } from "@grpc/grpc-js";
-import { CursorInUseError } from "../error";
+import { CursorInUseError } from "../../../error";
 import { Readable } from "stream";
+import { IterableCursor } from "src/types";
 
 /** @internal */
 export interface Initializer<TResp extends proto.Message> {
@@ -15,7 +16,9 @@ const tReady = Symbol("ready");
 /** @internal */
 const tClosed = Symbol("closed");
 
-export abstract class IterableStream<T, TResp extends proto.Message> {
+export abstract class GrpcIterableStream<T, TResp extends proto.Message>
+	implements IterableCursor<T>
+{
 	/** @internal */
 	[tStream]: ClientReadableStream<TResp>;
 	/** @internal */

--- a/src/driver/grpc/consumables/search-iterator.ts
+++ b/src/driver/grpc/consumables/search-iterator.ts
@@ -1,18 +1,19 @@
-import { Initializer, IterableStream } from "./iterable-stream";
+import { Initializer, GrpcIterableStream } from "./iterable-stream";
 import {
 	SearchRequest as ProtoSearchRequest,
 	SearchResponse as ProtoSearchResponse,
-} from "../proto/server/v1/api_pb";
+} from "../../../proto/server/v1/api_pb";
 
-import { TigrisClient } from "../proto/server/v1/api_grpc_pb";
+import { TigrisClient } from "../../../proto/server/v1/api_grpc_pb";
 import { ClientReadableStream } from "@grpc/grpc-js";
-import { TigrisClientConfig } from "../tigris";
+import { TigrisClientConfig } from "../../../tigris";
 import {
 	SearchIndexResponse as ProtoSearchIndexResponse,
 	SearchIndexRequest as ProtoSearchIndexRequest,
-} from "../proto/server/v1/search_pb";
-import { SearchClient } from "../proto/server/v1/search_grpc_pb";
-import { SearchResult } from "../search";
+} from "../../../proto/server/v1/search_pb";
+import { SearchClient } from "../../../proto/server/v1/search_grpc_pb";
+import { SearchResult } from "../../../search";
+import { toSearchResult } from "../search";
 
 /** @internal */
 export class SearchIteratorInitializer implements Initializer<ProtoSearchResponse> {
@@ -46,7 +47,7 @@ export class SearchIndexIteratorInitializer implements Initializer<ProtoSearchIn
 /**
  * Iterator to supplement search() queries
  */
-export class SearchIterator<T> extends IterableStream<
+export class SearchIterator<T> extends GrpcIterableStream<
 	SearchResult<T>,
 	ProtoSearchResponse | ProtoSearchIndexResponse
 > {
@@ -63,6 +64,6 @@ export class SearchIterator<T> extends IterableStream<
 
 	/** @override */
 	protected _transform(message: ProtoSearchResponse | ProtoSearchIndexResponse): SearchResult<T> {
-		return SearchResult.from(message, this._config);
+		return toSearchResult(message, this._config);
 	}
 }

--- a/src/driver/grpc/database.ts
+++ b/src/driver/grpc/database.ts
@@ -1,0 +1,264 @@
+import { DatabaseDriver } from "../driver";
+import { Utility } from "../../utility";
+import { TigrisClient } from "../../proto/server/v1/api_grpc_pb";
+import { Log } from "../../utils/logger";
+import { Metadata, ChannelCredentials, ServiceError } from "@grpc/grpc-js";
+import {
+	BeginTransactionRequest as ProtoBeginTransactionRequest,
+	BeginTransactionResponse,
+	CollectionOptions as ProtoCollectionOptions,
+	CreateBranchRequest as ProtoCreateBranchRequest,
+	CreateOrUpdateCollectionRequest as ProtoCreateOrUpdateCollectionRequest,
+	DeleteBranchRequest as ProtoDeleteBranchRequest,
+	DescribeDatabaseRequest as ProtoDescribeDatabaseRequest,
+	DropCollectionRequest as ProtoDropCollectionRequest,
+	ListCollectionsRequest as ProtoListCollectionsRequest,
+	CommitTransactionRequest as ProtoCommitTransactionRequest,
+	RollbackTransactionRequest as ProtoRollbackTransactionRequest,
+} from "../../proto/server/v1/api_pb";
+import { TigrisClientConfig } from "../../tigris";
+import { Status } from "@grpc/grpc-js/build/src/constants";
+import {
+	CollectionDescription,
+	CollectionInfo,
+	CollectionMetadata,
+	CollectionOptions,
+	CommitTransactionResponse,
+	CreateBranchResponse,
+	DatabaseDescription,
+	DatabaseMetadata,
+	DeleteBranchResponse,
+	DropCollectionResponse,
+	RollbackTransactionResponse,
+	Session,
+	TransactionOptions,
+} from "../../types";
+import { TigrisError } from "../../error";
+import { GrpcSession } from "./session";
+
+const SetCookie = "Set-Cookie";
+const Cookie = "Cookie";
+const BeginTransactionMethodName = "/tigrisdata.v1.Tigris/BeginTransaction";
+
+export class Database implements DatabaseDriver {
+	client: TigrisClient;
+	config: TigrisClientConfig;
+	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials) {
+		this.config = config;
+		this.client = new TigrisClient(config.serverUrl, channelCredentials);
+	}
+
+	createOrUpdateCollection(
+		project: string,
+		branch: string,
+		coll: string,
+		onlyCreate: false,
+		schema: string
+	): Promise<void> {
+		return new Promise((resolve, reject) => {
+			const createOrUpdateCollectionRequest = new ProtoCreateOrUpdateCollectionRequest()
+				.setProject(project)
+				.setBranch(branch)
+				.setCollection(coll)
+				.setOnlyCreate(onlyCreate)
+				.setSchema(Utility.stringToUint8Array(schema));
+
+			this.client.createOrUpdateCollection(
+				createOrUpdateCollectionRequest,
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				(error, _response) => {
+					if (error) {
+						reject(error);
+						return;
+					}
+					resolve();
+				}
+			);
+		});
+	}
+
+	public listCollections(
+		projectName: string,
+		branch: string,
+		options?: CollectionOptions
+	): Promise<Array<CollectionInfo>> {
+		return new Promise<Array<CollectionInfo>>((resolve, reject) => {
+			const request = new ProtoListCollectionsRequest().setProject(projectName).setBranch(branch);
+			if (typeof options !== "undefined") {
+				return request.setOptions(new ProtoCollectionOptions());
+			}
+			this.client.listCollections(request, (error, response) => {
+				if (error) {
+					reject(error);
+				} else {
+					const result = response
+						.getCollectionsList()
+						.map(
+							(collectionInfo) =>
+								new CollectionInfo(collectionInfo.getCollection(), new CollectionMetadata())
+						);
+					resolve(result);
+				}
+			});
+		});
+	}
+
+	dropCollection(
+		project: string,
+		branch: string,
+		collection: string
+	): Promise<DropCollectionResponse> {
+		return new Promise<DropCollectionResponse>((resolve, reject) => {
+			this.client.dropCollection(
+				new ProtoDropCollectionRequest()
+					.setProject(project)
+					.setBranch(branch)
+					.setCollection(collection),
+				(error, response) => {
+					if (error) {
+						reject(error);
+					} else {
+						resolve(new DropCollectionResponse(response.getMessage()));
+					}
+				}
+			);
+		});
+	}
+
+	describe(name: string, branch: string): Promise<DatabaseDescription> {
+		return new Promise<DatabaseDescription>((resolve, reject) => {
+			this.client.describeDatabase(
+				new ProtoDescribeDatabaseRequest().setProject(name).setBranch(branch),
+				(error, response) => {
+					if (error) {
+						reject(error);
+					} else {
+						const collectionsDescription: CollectionDescription[] = [];
+						for (let i = 0; i < response.getCollectionsList().length; i++) {
+							collectionsDescription.push(
+								new CollectionDescription(
+									response.getCollectionsList()[i].getCollection(),
+									new CollectionMetadata(),
+									response.getCollectionsList()[i].getSchema_asB64()
+								)
+							);
+						}
+						resolve(
+							new DatabaseDescription(
+								new DatabaseMetadata(),
+								collectionsDescription,
+								response.getBranchesList()
+							)
+						);
+					}
+				}
+			);
+		});
+	}
+
+	public beginTransaction(
+		name: string,
+		branch: string,
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		_options?: TransactionOptions
+	): Promise<Session> {
+		return new Promise<Session>((resolve, reject) => {
+			const beginTxRequest = new ProtoBeginTransactionRequest().setProject(name).setBranch(branch);
+			const cookie: Metadata = new Metadata();
+			const call = this.client.makeUnaryRequest(
+				BeginTransactionMethodName,
+				(value) => Buffer.from(value.serializeBinary()),
+				(value) => BeginTransactionResponse.deserializeBinary(value),
+				beginTxRequest,
+				(error: ServiceError, response: BeginTransactionResponse) => {
+					if (error) {
+						reject(error);
+					} else {
+						// on metadata is expected to have invoked at this point since response
+						// is served
+						resolve(
+							new GrpcSession(
+								response.getTxCtx().getId(),
+								response.getTxCtx().getOrigin(),
+								this.client,
+								name,
+								branch,
+								cookie
+							)
+						);
+					}
+				}
+			);
+			call.on("metadata", (metadata) => {
+				if (metadata.get(SetCookie)) {
+					for (const inboundCookie of metadata.get(SetCookie)) cookie.add(Cookie, inboundCookie);
+				}
+			});
+		});
+	}
+
+	commit(db: string, branch: string, metadata: Metadata): Promise<CommitTransactionResponse> {
+		return new Promise<CommitTransactionResponse>((resolve, reject) => {
+			const request = new ProtoCommitTransactionRequest().setProject(db).setBranch(branch);
+			this.client.commitTransaction(request, metadata, (error, response) => {
+				if (error) {
+					reject(error);
+				} else {
+					resolve(new CommitTransactionResponse(response.getStatus()));
+				}
+			});
+		});
+	}
+
+	public rollback(
+		db: string,
+		branch: string,
+		metadata: Metadata
+	): Promise<RollbackTransactionResponse> {
+		return new Promise<RollbackTransactionResponse>((resolve, reject) => {
+			const request = new ProtoRollbackTransactionRequest().setProject(db).setBranch(branch);
+			this.client.rollbackTransaction(request, metadata, (error, response) => {
+				if (error) {
+					reject(error);
+				} else {
+					resolve(new RollbackTransactionResponse(response.getStatus()));
+				}
+			});
+		});
+	}
+
+	public createBranch(name: string, branch: string): Promise<CreateBranchResponse> {
+		return new Promise((resolve, reject) => {
+			const req = new ProtoCreateBranchRequest().setProject(name).setBranch(branch);
+			this.client.createBranch(req, (error, response) => {
+				if (error) {
+					if ((error as ServiceError).code === Status.ALREADY_EXISTS) {
+						return reject(new TigrisError(`'${branch}' branch already exists`));
+					}
+
+					if (error.code === Status.NOT_FOUND) {
+						const msg = `The project ${name} could not be found. Please ensure ${name} exists in your Tigris deployment or target Tigris region.`;
+						Log.error(msg);
+					}
+
+					reject(error);
+					return;
+				}
+				resolve(CreateBranchResponse.from(response));
+			});
+		});
+	}
+
+	public deleteBranch(name: string, branch: string): Promise<DeleteBranchResponse> {
+		return new Promise((resolve, reject) => {
+			const req = new ProtoDeleteBranchRequest().setProject(name).setBranch(branch);
+			this.client.deleteBranch(req, (error, response) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(DeleteBranchResponse.from(response));
+			});
+		});
+	}
+}

--- a/src/driver/grpc/database.ts
+++ b/src/driver/grpc/database.ts
@@ -2,7 +2,7 @@ import { DatabaseDriver } from "../driver";
 import { Utility } from "../../utility";
 import { TigrisClient } from "../../proto/server/v1/api_grpc_pb";
 import { Log } from "../../utils/logger";
-import { Metadata, ChannelCredentials, ServiceError } from "@grpc/grpc-js";
+import { Metadata, ChannelCredentials, ServiceError, ClientOptions } from "@grpc/grpc-js";
 import {
 	BeginTransactionRequest as ProtoBeginTransactionRequest,
 	BeginTransactionResponse,
@@ -43,9 +43,14 @@ const BeginTransactionMethodName = "/tigrisdata.v1.Tigris/BeginTransaction";
 export class Database implements DatabaseDriver {
 	client: TigrisClient;
 	config: TigrisClientConfig;
-	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials) {
+
+	constructor(
+		config: TigrisClientConfig,
+		channelCredentials: ChannelCredentials,
+		opts: ClientOptions
+	) {
 		this.config = config;
-		this.client = new TigrisClient(config.serverUrl, channelCredentials);
+		this.client = new TigrisClient(config.serverUrl, channelCredentials, opts);
 	}
 
 	createOrUpdateCollection(

--- a/src/driver/grpc/grpc.ts
+++ b/src/driver/grpc/grpc.ts
@@ -1,0 +1,179 @@
+import Driver, {
+	CacheDriver,
+	CollectionDriver,
+	DatabaseDriver,
+	ObservabilityDriver,
+	SearchDriver,
+} from "../driver";
+import { TigrisClient } from "../../proto/server/v1/api_grpc_pb";
+import * as grpc from "@grpc/grpc-js";
+import { Metadata, ChannelCredentials, ClientOptions } from "@grpc/grpc-js";
+import { HealthCheckInput as ProtoHealthCheckInput } from "../../proto/server/v1/health_pb";
+import {
+	GetAccessTokenRequest as ProtoGetAccessTokenRequest,
+	GrantType,
+} from "../../proto/server/v1/auth_pb";
+import { AuthClient } from "../../proto/server/v1/auth_grpc_pb";
+import { HealthAPIClient } from "../../proto/server/v1/health_grpc_pb";
+import { TigrisClientConfig } from "../../tigris";
+import { TokenSupplier } from "../../tokensupplier";
+import { Database } from "./database";
+import { GrpcCollectionDriver } from "./collection";
+import { Cache } from "./cache";
+import { Observability } from "./observability";
+import { Search } from "./search";
+import { ServiceConfig } from "@grpc/grpc-js/build/src/service-config";
+
+const AuthorizationHeaderName = "authorization";
+const AuthorizationBearer = "Bearer ";
+const USER_AGENT_KEY = "user-agent";
+const USER_AGENT_VAL = "tigris-client-ts.grpc";
+const DEST_NAME_KEY = "destination-name";
+
+export default class GrpcDriver implements Driver {
+	grpcClient: TigrisClient;
+	authClient: AuthClient;
+	healthClient: HealthAPIClient;
+	cacheDriver: CacheDriver;
+	observabilityDriver: ObservabilityDriver;
+	searchDriver: SearchDriver;
+	databaseDriver: DatabaseDriver;
+	channelCreds: ChannelCredentials;
+	private readonly _config: TigrisClientConfig;
+
+	constructor(config: TigrisClientConfig) {
+		const svcConfig: ServiceConfig = {
+			loadBalancingConfig: [],
+			methodConfig: [
+				{
+					name: [
+						{
+							service: "tigrisdata.v1.Tigris",
+						},
+						{
+							service: "tigrisdata.search.v1.Search",
+						},
+					],
+					waitForReady: true,
+					retryPolicy: {
+						maxAttempts: 3,
+						initialBackoff: "0.1s",
+						maxBackoff: "1.0s",
+						backoffMultiplier: 1.5,
+						retryableStatusCodes: [
+							status.UNAVAILABLE,
+							status.UNKNOWN,
+							status.INTERNAL,
+							status.RESOURCE_EXHAUSTED,
+						],
+					},
+				},
+			],
+		};
+
+		const grpcOptions: ClientOptions = {
+			"grpc.service_config": JSON.stringify(svcConfig),
+			"grpc.enable_retries": 1,
+		};
+		this._config = config;
+		this.authClient = new AuthClient(config.serverUrl, grpc.credentials.createSsl());
+		this.channelCreds = this.getChannelCreds(config);
+		this.grpcClient = new TigrisClient(config.serverUrl, this.channelCreds);
+		this.cacheDriver = new Cache(this._config, this.channelCreds);
+		this.healthClient = new HealthAPIClient(config.serverUrl, this.channelCreds);
+		this.observabilityDriver = new Observability(config, this.channelCreds);
+		this.searchDriver = new Search(config, this.channelCreds);
+		this.databaseDriver = new Database(config, this.channelCreds);
+	}
+
+	database(): DatabaseDriver {
+		return this.databaseDriver;
+	}
+
+	collection<T>(): CollectionDriver<T> {
+		return new GrpcCollectionDriver<T>(this._config, this.channelCreds);
+	}
+
+	observability(): ObservabilityDriver {
+		return this.observabilityDriver;
+	}
+
+	cache(): CacheDriver {
+		return this.cacheDriver;
+	}
+
+	search(): SearchDriver {
+		return this.searchDriver;
+	}
+
+	getChannelCreds(config: TigrisClientConfig) {
+		const defaultMetadata = new Metadata();
+		defaultMetadata.set(USER_AGENT_KEY, USER_AGENT_VAL);
+		defaultMetadata.set(DEST_NAME_KEY, config.serverUrl);
+
+		if (this.isLocalServer(config)) {
+			return grpc.credentials.createInsecure();
+		} else if (config.clientId === undefined || config.clientSecret === undefined) {
+			throw new Error("Both `clientId` and `clientSecret` are required");
+		} else {
+			const tokenSupplier = new TokenSupplier(config, this);
+			return grpc.credentials.combineChannelCredentials(
+				grpc.credentials.createSsl(),
+				grpc.credentials.createFromMetadataGenerator((_params, callback) => {
+					tokenSupplier
+						.getAccessToken()
+						.then((accessToken) => {
+							const md = new grpc.Metadata();
+							md.set(AuthorizationHeaderName, AuthorizationBearer + accessToken);
+							md.merge(defaultMetadata);
+							return callback(undefined, md);
+						})
+						.catch((error) => {
+							return callback(error);
+						});
+				})
+			);
+		}
+	}
+
+	isLocalServer(config: TigrisClientConfig) {
+		return (
+			(config.serverUrl.includes("localhost") ||
+				config.serverUrl.startsWith("tigris-local-server:") ||
+				config.serverUrl.includes("127.0.0.1") ||
+				config.serverUrl.includes("[::1]")) &&
+			config.clientId === undefined &&
+			config.clientSecret === undefined
+		);
+	}
+
+	health(): Promise<string> {
+		return new Promise((resolve, reject) => {
+			this.healthClient.health(new ProtoHealthCheckInput(), (error, response) => {
+				if (error) {
+					return reject(error);
+				}
+				resolve(response.getResponse());
+			});
+		});
+	}
+	getAccessToken(clientId: string, clientSecret: string): Promise<string> {
+		return new Promise<string>((resolve, reject) => {
+			// refresh
+			this.authClient.getAccessToken(
+				new ProtoGetAccessTokenRequest()
+					.setGrantType(GrantType.CLIENT_CREDENTIALS)
+					.setClientId(clientId)
+					.setClientSecret(clientSecret),
+				(error, response) => {
+					if (error) {
+						reject(error);
+					} else {
+						const accessToken = response.getAccessToken();
+						resolve(accessToken);
+					}
+				}
+			);
+		});
+	}
+}

--- a/src/driver/grpc/observability.ts
+++ b/src/driver/grpc/observability.ts
@@ -1,0 +1,24 @@
+import { ObservabilityDriver } from "../driver";
+import { ChannelCredentials } from "@grpc/grpc-js";
+import { ObservabilityClient } from "../../proto/server/v1/observability_grpc_pb";
+import { GetInfoRequest as ProtoGetInfoRequest } from "../../proto/server/v1/observability_pb";
+import { TigrisClientConfig } from "../../tigris";
+import { ServerMetadata } from "../../types";
+
+export class Observability implements ObservabilityDriver {
+	observabilityClient: ObservabilityClient;
+	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials) {
+		this.observabilityClient = new ObservabilityClient(config.serverUrl, channelCredentials);
+	}
+	getInfo(): Promise<ServerMetadata> {
+		return new Promise<ServerMetadata>((resolve, reject) => {
+			this.observabilityClient.getInfo(new ProtoGetInfoRequest(), (error, response) => {
+				if (error) {
+					reject(error);
+				} else {
+					resolve(new ServerMetadata(response.getServerVersion()));
+				}
+			});
+		});
+	}
+}

--- a/src/driver/grpc/observability.ts
+++ b/src/driver/grpc/observability.ts
@@ -1,5 +1,5 @@
 import { ObservabilityDriver } from "../driver";
-import { ChannelCredentials } from "@grpc/grpc-js";
+import { ChannelCredentials, ClientOptions } from "@grpc/grpc-js";
 import { ObservabilityClient } from "../../proto/server/v1/observability_grpc_pb";
 import { GetInfoRequest as ProtoGetInfoRequest } from "../../proto/server/v1/observability_pb";
 import { TigrisClientConfig } from "../../tigris";
@@ -7,8 +7,12 @@ import { ServerMetadata } from "../../types";
 
 export class Observability implements ObservabilityDriver {
 	observabilityClient: ObservabilityClient;
-	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials) {
-		this.observabilityClient = new ObservabilityClient(config.serverUrl, channelCredentials);
+	constructor(
+		config: TigrisClientConfig,
+		channelCredentials: ChannelCredentials,
+		opts: ClientOptions
+	) {
+		this.observabilityClient = new ObservabilityClient(config.serverUrl, channelCredentials, opts);
 	}
 	getInfo(): Promise<ServerMetadata> {
 		return new Promise<ServerMetadata>((resolve, reject) => {

--- a/src/driver/grpc/search.ts
+++ b/src/driver/grpc/search.ts
@@ -60,12 +60,16 @@ export class Search implements SearchDriver {
 	client: SearchClient;
 	tigrisClient: TigrisClient;
 	config: TigrisClientConfig;
-	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials | undefined) {
+	constructor(
+		config: TigrisClientConfig,
+		channelCredentials: ChannelCredentials | undefined,
+		opts: grpc.ClientOptions
+	) {
 		this.config = config;
 		// TODO: to remove later this is for testing
 		if (channelCredentials) {
-			this.client = new SearchClient(config.serverUrl, channelCredentials);
-			this.tigrisClient = new TigrisClient(config.serverUrl, channelCredentials);
+			this.client = new SearchClient(config.serverUrl, channelCredentials, opts);
+			this.tigrisClient = new TigrisClient(config.serverUrl, channelCredentials, opts);
 		}
 	}
 

--- a/src/driver/grpc/search.ts
+++ b/src/driver/grpc/search.ts
@@ -1,0 +1,378 @@
+import { SearchDriver } from "../driver";
+import { Utility } from "../../utility";
+import { TigrisClient } from "../../proto/server/v1/api_grpc_pb";
+import * as grpc from "@grpc/grpc-js";
+import { ChannelCredentials } from "@grpc/grpc-js";
+import {
+	SearchRequest as ProtoSearchRequest,
+	SearchResponse as ProtoSearchResponse,
+	FacetCount as ProtoFacetCount,
+	FacetStats as ProtoFacetStats,
+	Page as ProtoSearchPage,
+	SearchFacet as ProtoSearchFacet,
+	SearchHit as ProtoSearchHit,
+	SearchHitMeta as ProtoSearchHitMeta,
+	SearchMetadata as ProtoSearchMetadata,
+	Match as ProtoMatch,
+	GroupedSearchHits,
+} from "../../proto/server/v1/api_pb";
+import {
+	CreateDocumentRequest as ProtoCreateDocumentRequest,
+	CreateOrReplaceDocumentRequest as ProtoSearchReplaceRequest,
+	DeleteByQueryRequest as ProtoDeleteByQueryRequest,
+	DeleteDocumentRequest as ProtoDeleteDocumentRequest,
+	GetDocumentRequest as ProtoGetDocumentRequest,
+	SearchIndexRequest as ProtoSearchIndexRequest,
+	SearchIndexResponse as ProtoSearchIndexResponse,
+	UpdateDocumentRequest as ProtoUpdateDocumentRequest,
+	CreateOrUpdateIndexRequest as ProtoCreateIndexRequest,
+	DeleteIndexRequest as ProtoDeleteIndexRequest,
+	ListIndexesRequest as ProtoListIndexesRequest,
+	DocStatus as ProtoDocStatus,
+} from "../../proto/server/v1/search_pb";
+import { TigrisClientConfig } from "../../tigris";
+import {
+	DocMeta,
+	DocStatus,
+	FacetCount,
+	FacetCountDistribution,
+	FacetStats,
+	Facets,
+	IndexInfo,
+	IndexedDoc,
+	Page,
+	SearchCursor,
+	SearchIterator,
+	SearchMeta,
+	SearchQuery,
+	SearchResult,
+	TextMatchInfo,
+} from "../../search";
+import { SearchClient } from "../../proto/server/v1/search_grpc_pb";
+import {
+	SearchIndexIteratorInitializer,
+	SearchIteratorInitializer,
+} from "./consumables/search-iterator";
+import { TigrisError } from "../../error";
+import { TigrisCollectionType } from "../../types";
+
+export class Search implements SearchDriver {
+	client: SearchClient;
+	tigrisClient: TigrisClient;
+	config: TigrisClientConfig;
+	constructor(config: TigrisClientConfig, channelCredentials: ChannelCredentials | undefined) {
+		this.config = config;
+		// TODO: to remove later this is for testing
+		if (channelCredentials) {
+			this.client = new SearchClient(config.serverUrl, channelCredentials);
+			this.tigrisClient = new TigrisClient(config.serverUrl, channelCredentials);
+		}
+	}
+
+	getClient() {
+		return this.client;
+	}
+
+	createOrUpdateIndex(index: string, schema: Uint8Array): Promise<string> {
+		const createOrUpdateIndexRequest = new ProtoCreateIndexRequest()
+			.setProject(this.config.projectName)
+			.setName(index)
+			.setSchema(schema);
+		return new Promise<string>((resolve, reject) => {
+			this.client.createOrUpdateIndex(createOrUpdateIndexRequest, (error, response) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(response.getMessage());
+			});
+		});
+	}
+	listIndexes(): Promise<IndexInfo[]> {
+		const listIndexRequest = new ProtoListIndexesRequest().setProject(this.config.projectName);
+		return new Promise<Array<IndexInfo>>((resolve, reject) => {
+			this.client.listIndexes(listIndexRequest, (error, response) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(
+					response.getIndexesList().map((i) => IndexInfo.from(i.getName(), i.getSchema_asB64()))
+				);
+			});
+		});
+	}
+	deleteIndex(name: string): Promise<string> {
+		const deleteIndexRequest = new ProtoDeleteIndexRequest()
+			.setProject(this.config.projectName)
+			.setName(name);
+
+		return new Promise<string>((resolve, reject) => {
+			this.client.deleteIndex(deleteIndexRequest, (error, response) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(response.getMessage());
+			});
+		});
+	}
+
+	createMany(name: string, docs: Uint8Array[]): Promise<DocStatus[]> {
+		return new Promise<DocStatus[]>((resolve, reject) => {
+			const createRequest = new ProtoCreateDocumentRequest()
+				.setProject(this.config.projectName)
+				.setIndex(name)
+				.setDocumentsList(docs);
+			this.client.create(createRequest, (error, response) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(toDocStatus(response.getStatusList()));
+			});
+		});
+	}
+	createOrReplaceMany(name: string, docs: Uint8Array[]): Promise<DocStatus[]> {
+		return new Promise<Array<DocStatus>>((resolve, reject) => {
+			const replaceRequest = new ProtoSearchReplaceRequest()
+				.setProject(this.config.projectName)
+				.setIndex(name)
+				.setDocumentsList(docs);
+
+			this.client.createOrReplace(replaceRequest, (error, response) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(toDocStatus(response.getStatusList()));
+			});
+		});
+	}
+	deleteMany(name: string, ids: string[]): Promise<DocStatus[]> {
+		return new Promise<Array<DocStatus>>((resolve, reject) => {
+			const delRequest = new ProtoDeleteDocumentRequest()
+				.setProject(this.config.projectName)
+				.setIndex(name)
+				.setIdsList(ids);
+			this.client.delete(delRequest, (error, response) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(toDocStatus(response.getStatusList()));
+			});
+		});
+	}
+	deleteByQuery(name: string, filter: Uint8Array): Promise<number> {
+		return new Promise<number>((resolve, reject) => {
+			const delRequest = new ProtoDeleteByQueryRequest()
+				.setProject(this.config.projectName)
+				.setIndex(name)
+				.setFilter(filter);
+
+			this.client.deleteByQuery(delRequest, (error, response) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(response.getCount());
+			});
+		});
+	}
+	getMany<T>(name: string, ids: string[]): Promise<IndexedDoc<T>[]> {
+		return new Promise<Array<IndexedDoc<T>>>((resolve, reject) => {
+			const getRequest = new ProtoGetDocumentRequest()
+				.setProject(this.config.projectName)
+				.setIndex(name)
+				.setIdsList(ids);
+			this.client.get(getRequest, (error, response) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				const docs: IndexedDoc<T>[] = response.getDocumentsList().map((d) => {
+					return toIndexedDoc(d, this.config);
+				});
+				resolve(docs);
+			});
+		});
+	}
+	updateMany(name: string, docs: Uint8Array[]): Promise<DocStatus[]> {
+		return new Promise<Array<DocStatus>>((resolve, reject) => {
+			const updateRequest = new ProtoUpdateDocumentRequest()
+				.setProject(this.config.projectName)
+				.setDocumentsList(docs)
+				.setIndex(name);
+
+			this.client.update(updateRequest, (error, response) => {
+				if (error) {
+					reject(error);
+				}
+				resolve(toDocStatus(response.getStatusList()));
+			});
+		});
+	}
+
+	searchCollection<T>(
+		db: string,
+		branch: string,
+		collectionName: string,
+		query: SearchQuery<T>,
+		page?: number
+	): SearchCursor<T> | Promise<SearchResult<T>> {
+		const searchRequest = new ProtoSearchRequest()
+			.setProject(db)
+			.setBranch(branch)
+			.setCollection(collectionName);
+
+		Utility.protoSearchRequestFromQuery(query, searchRequest, page);
+
+		// return a iterator if no explicit page number is specified
+		if (typeof page === "undefined") {
+			const initializer = new SearchIteratorInitializer(this.tigrisClient, searchRequest);
+			return new SearchIterator<T>(initializer, this.config);
+		} else {
+			return new Promise<SearchResult<T>>((resolve, reject) => {
+				const stream: grpc.ClientReadableStream<ProtoSearchResponse> =
+					this.tigrisClient.search(searchRequest);
+
+				stream.on("data", (searchResponse: ProtoSearchResponse) => {
+					const searchResult: SearchResult<T> = toSearchResult(searchResponse, this.config);
+					resolve(searchResult);
+				});
+				stream.on("error", (error) => reject(error));
+				stream.on("end", () => resolve(SearchResult.empty));
+			});
+		}
+	}
+
+	search<T>(
+		name: string,
+		query: SearchQuery<T>,
+		page?: number
+	): SearchCursor<T> | Promise<SearchResult<T>> {
+		const searchRequest = new ProtoSearchIndexRequest()
+			.setProject(this.config.projectName)
+			.setIndex(name);
+
+		Utility.protoSearchRequestFromQuery(query, searchRequest, page);
+
+		// return a iterator if no explicit page number is specified
+		if (typeof page === "undefined") {
+			const initializer = new SearchIndexIteratorInitializer(this.client, searchRequest);
+			return new SearchIterator<T>(initializer, this.config);
+		} else {
+			return new Promise<SearchResult<T>>((resolve, reject) => {
+				const stream: grpc.ClientReadableStream<ProtoSearchIndexResponse> =
+					this.client.search(searchRequest);
+
+				stream.on("data", (searchResponse: ProtoSearchIndexResponse) => {
+					const searchResult: SearchResult<T> = toSearchResult(searchResponse, this.config);
+					resolve(searchResult);
+				});
+				stream.on("error", (error) => reject(error));
+				stream.on("end", () => resolve(SearchResult.empty));
+			});
+		}
+	}
+}
+
+export function toSearchResult<T>(
+	resp: ProtoSearchIndexResponse,
+	config: TigrisClientConfig
+): SearchResult<T> {
+	const _meta =
+		typeof resp?.getMeta() !== "undefined" ? toSearchMeta(resp.getMeta()) : SearchMeta.default;
+	const _hits: Array<IndexedDoc<T>> = resp
+		.getHitsList()
+		.map((h: ProtoSearchHit) => toIndexedDoc<T>(h, config));
+	const _facets: Facets = {};
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	for (const [k, _] of resp.getFacetsMap().toArray()) {
+		_facets[k] = toFacetDistribution(resp.getFacetsMap().get(k));
+	}
+	const _groupedHits = resp.getGroupList().map((g: GroupedSearchHits) => {
+		return {
+			groupKeys: g.getGroupKeysList(),
+			hits: g.getHitsList().map((h: ProtoSearchHit) => toIndexedDoc<T>(h, config)),
+		};
+	});
+
+	return new SearchResult(_hits, _facets, _meta, _groupedHits);
+}
+
+export function toSearchMeta(resp: ProtoSearchMetadata): SearchMeta {
+	const found = resp?.getFound() ?? 0;
+	const totalPages = resp?.getTotalPages() ?? 0;
+	const page = typeof resp?.getPage() !== "undefined" ? toPage(resp.getPage()) : undefined;
+	return new SearchMeta(found, totalPages, page, resp.getMatchedFieldsList());
+}
+
+function toFacetDistribution(resp: ProtoSearchFacet): FacetCountDistribution {
+	const stats = typeof resp?.getStats() !== "undefined" ? toFacetStats(resp.getStats()) : undefined;
+	const counts = resp.getCountsList().map((c) => toFacetCount(c));
+	return new FacetCountDistribution(counts, stats);
+}
+
+function toPage(resp: ProtoSearchPage): Page {
+	const current = resp?.getCurrent() ?? 0;
+	const size = resp?.getSize() ?? 0;
+	return new Page(current, size);
+}
+
+function toFacetStats(resp: ProtoFacetStats): FacetStats {
+	return new FacetStats(
+		resp?.getAvg() ?? 0,
+		resp?.getCount() ?? 0,
+		resp?.getMax() ?? 0,
+		resp?.getMin() ?? 0,
+		resp?.getSum() ?? 0
+	);
+}
+
+function toFacetCount(resp: ProtoFacetCount): FacetCount {
+	return new FacetCount(resp.getValue(), resp.getCount());
+}
+
+export function toDocStatus(protoStatus: ProtoDocStatus[]): DocStatus[] {
+	return protoStatus.map((protoStatus) => {
+		const err = protoStatus.hasError()
+			? new TigrisError(protoStatus.getError().getMessage())
+			: undefined;
+		return new DocStatus(protoStatus.getId(), err);
+	});
+}
+
+export function toIndexedDoc<T extends TigrisCollectionType>(
+	resp: ProtoSearchHit,
+	config: TigrisClientConfig
+): IndexedDoc<T> {
+	const docAsB64 = resp.getData_asB64();
+	if (!docAsB64) {
+		return new IndexedDoc<T>(undefined, undefined);
+	}
+	const document = Utility.jsonStringToObj<T>(Utility._base64Decode(docAsB64), config);
+	const meta = resp.hasMetadata() ? toDocMeta(resp.getMetadata()) : undefined;
+	return new IndexedDoc<T>(document, meta);
+}
+
+export function toDocMeta(resp: ProtoSearchHitMeta): DocMeta {
+	const _createdAt =
+		typeof resp?.getCreatedAt()?.getSeconds() !== "undefined"
+			? new Date(resp.getCreatedAt().getSeconds() * 1000)
+			: undefined;
+	const _updatedAt =
+		typeof resp?.getUpdatedAt()?.getSeconds() !== "undefined"
+			? new Date(resp.getUpdatedAt().getSeconds() * 1000)
+			: undefined;
+	const _textMatch =
+		typeof resp?.getMatch() !== "undefined" ? toTextMatchInfo(resp.getMatch()) : undefined;
+
+	return new DocMeta(_createdAt, _updatedAt, _textMatch);
+}
+
+export function toTextMatchInfo(resp: ProtoMatch): TextMatchInfo {
+	const matchFields: Array<string> = resp.getFieldsList().map((f) => f.getName());
+	return new TextMatchInfo(matchFields, resp.getScore(), resp.getVectorDistance());
+}

--- a/src/driver/grpc/session.ts
+++ b/src/driver/grpc/session.ts
@@ -1,13 +1,13 @@
-import { TigrisClient } from "./proto/server/v1/api_grpc_pb";
+import { TigrisClient } from "../../proto/server/v1/api_grpc_pb";
 import {
 	CommitTransactionRequest as ProtoCommitTransactionRequest,
 	RollbackTransactionRequest as ProtoRollbackTransactionRequest,
-} from "./proto/server/v1/api_pb";
-import { CommitTransactionResponse, RollbackTransactionResponse } from "./types";
-import { Utility } from "./utility";
+} from "../../proto/server/v1/api_pb";
+import { CommitTransactionResponse, RollbackTransactionResponse, Session } from "../../types";
+import { Utility } from "../../utility";
 import { Metadata } from "@grpc/grpc-js";
 
-export class Session {
+export class GrpcSession implements Session {
 	private readonly _id: string;
 	private readonly _origin: string;
 	private readonly grpcClient: TigrisClient;

--- a/src/driver/http.ts
+++ b/src/driver/http.ts
@@ -1,0 +1,84 @@
+// import { OpenApiClient } from "../http/v1";
+import Driver, {
+	CacheDriver,
+	CollectionDriver,
+	DatabaseDriver,
+	ObservabilityDriver,
+	SearchDriver,
+} from "./driver";
+// import {
+// 	CreateOrUpdateCollectionRequest,
+// 	GetAccessTokenRequest,
+// 	GetAccessTokenResponse,
+// } from "../http/v1";
+import { TigrisClientConfig } from "../tigris";
+import { DeleteCacheResponse, ListCachesResponse } from "../types";
+
+export class HttpDriver implements Driver {
+	// private client: OpenApiClient;
+	constructor(config: TigrisClientConfig) {
+		// this.client = new OpenApiClient({
+		// 	BASE: config.serverUrl,
+		// 	USERNAME: config.clientId,
+		// 	PASSWORD: config.clientSecret,
+		// });
+	}
+	collection<T>(): CollectionDriver<T> {
+		throw new Error("Method not implemented.");
+	}
+	database(): DatabaseDriver {
+		throw new Error("Method not implemented.");
+	}
+	search(): SearchDriver {
+		throw new Error("Method not implemented.");
+	}
+	observability(): ObservabilityDriver {
+		throw new Error("Method not implemented.");
+	}
+	cache(): CacheDriver {
+		throw new Error("Method not implemented.");
+	}
+	listCaches(): Promise<ListCachesResponse> {
+		throw new Error("Method not implemented.");
+	}
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	deleteCache(name: string): Promise<DeleteCacheResponse> {
+		throw new Error("Method not implemented.");
+	}
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	createCache(name: string): Promise<void> {
+		throw new Error("Method not implemented.");
+	}
+	health(): Promise<string> {
+		throw new Error("Method not implemented.");
+	}
+	async getAccessToken(clientId: string, clientSecret: string): Promise<string> {
+		throw new Error("Method not implemented.");
+		// const request: GetAccessTokenRequest = {
+		// 	grant_type: "CLIENT_CREDENTIALS",
+		// 	client_id: clientId,
+		// 	client_secret: clientSecret,
+		// };
+		// const resp = (await this.client.authentication.authGetAccessToken(
+		// 	request
+		// )) as GetAccessTokenResponse;
+		// return resp.access_token;
+	}
+
+	async createOrUpdateCollection(
+		project: string,
+		branch: string,
+		coll: string,
+		only_create: boolean,
+		schema: string
+	): Promise<void> {
+		throw new Error("Method not implemented.");
+		// const body: CreateOrUpdateCollectionRequest = {
+		// 	branch,
+		// 	schema: Utility.stringToUint8Array(schema),
+		// 	only_create,
+		// };
+
+		// await this.client.collections.tigrisCreateOrUpdateCollection(project, coll, body);
+	}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export * from "./collection";
 export * from "./db";
-export * from "./session";
 export * from "./tigris";
 export * from "./types";
 export * from "./constants";
@@ -8,5 +7,5 @@ export { Field } from "./decorators/tigris-field";
 export { PrimaryKey } from "./decorators/tigris-primary-key";
 export { TigrisCollection } from "./decorators/tigris-collection";
 export { EmbeddedFieldOptions } from "./decorators/options/embedded-field-options";
-export { Cursor } from "./consumables/cursor";
+export { GrpcCursor as Cursor } from "./driver/grpc/consumables/cursor";
 export * from "./search/index";

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -2,7 +2,7 @@ export * from "./types";
 export * from "./query";
 export * from "./result";
 export * from "./search-index";
-export { SearchIterator } from "../consumables/search-iterator";
+export { SearchIterator } from "../driver/grpc/consumables/search-iterator";
 export { SearchField } from "../decorators/tigris-search-field";
 export { Search } from "./search";
 export { TigrisSearchIndex } from "../decorators/tigris-search-index";

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -1,11 +1,6 @@
 import { TigrisArrayItem, TigrisDataTypes, TigrisResponse } from "../types";
 
 import { Utility } from "../utility";
-import {
-	DeleteIndexResponse as ProtoDeleteIndexResponse,
-	DocStatus as ProtoDocStatus,
-	IndexInfo as ProtoIndexInfo,
-} from "../proto/server/v1/search_pb";
 import { Status } from "../constants";
 import { TigrisError } from "../error";
 
@@ -35,11 +30,9 @@ export class IndexInfo {
 		this._schema = schema;
 	}
 
-	static from(info: ProtoIndexInfo): IndexInfo {
-		const schema = info.getSchema()
-			? JSON.parse(Utility._base64Decode(info.getSchema_asB64()))
-			: {};
-		return new this(info.getName(), schema);
+	static from(name: string, schemaAsB64: string): IndexInfo {
+		const schema = schemaAsB64 ? JSON.parse(Utility._base64Decode(schemaAsB64)) : {};
+		return new this(name, schema);
 	}
 
 	get name(): string {
@@ -61,10 +54,6 @@ export class DeleteIndexResponse implements TigrisResponse {
 	get message(): string {
 		return this._message;
 	}
-
-	static from(resp: ProtoDeleteIndexResponse): DeleteIndexResponse {
-		return new this(resp.getMessage());
-	}
 }
 
 export class DocStatus {
@@ -74,12 +63,5 @@ export class DocStatus {
 	constructor(id: string, error: TigrisError) {
 		this.id = id;
 		this.error = error;
-	}
-
-	static from(protoStatus: ProtoDocStatus): DocStatus {
-		const err = protoStatus.hasError()
-			? new TigrisError(protoStatus.getError().getMessage())
-			: undefined;
-		return new this(protoStatus.getId(), err);
 	}
 }

--- a/src/tokensupplier.ts
+++ b/src/tokensupplier.ts
@@ -1,0 +1,41 @@
+import Driver from "./driver/driver";
+import { TigrisClientConfig } from "./tigris";
+import { Utility } from "./utility";
+
+export class TokenSupplier {
+	private readonly clientId: string;
+	private readonly clientSecret: string;
+	private readonly config: TigrisClientConfig;
+	private readonly driver: Driver;
+
+	private accessToken: string;
+	private nextRefreshTime: number;
+
+	constructor(config: TigrisClientConfig, driver: Driver) {
+		this.clientId = config.clientId;
+		this.clientSecret = config.clientSecret;
+		this.config = config;
+		this.driver = driver;
+	}
+
+	async getAccessToken(): Promise<string> {
+		if (this.shouldRefresh()) {
+			this.accessToken = await this.driver.getAccessToken(this.clientId, this.clientSecret);
+		}
+		const parts: string[] = this.accessToken.split(".");
+		const exp = Number(
+			Utility.jsonStringToObj(Utility._base64Decode(parts[1]), this.config)["exp"]
+		);
+		// 5 min before expiry (note: exp is in seconds)
+		// add random jitter of 1-5 min (i.e. 60000 - 300000 ms)
+		this.nextRefreshTime = exp * 1000 - 300_000 - (Utility._getRandomInt(300_000) + 60_000);
+		return this.accessToken;
+	}
+
+	shouldRefresh(): boolean {
+		if (typeof this.accessToken === "undefined") {
+			return true;
+		}
+		return Date.now() >= this.nextRefreshTime;
+	}
+}

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,6 +1,6 @@
 import { Metadata } from "@grpc/grpc-js";
 import json_bigint from "json-bigint";
-import { Session } from "./session";
+import { GrpcSession } from "./driver/grpc/session";
 
 import {
 	DeleteQueryOptions,
@@ -155,7 +155,7 @@ export const Utility = {
 			/(\d{4}-[01]\d-[0-3]\dT[0-2](?:\d:[0-5]){2}\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2](?:\d:[0-5]){2}\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))/;
 		return isoDateRegex.test(value);
 	},
-	txToMetadata(tx: Session): Metadata {
+	txToMetadata(tx: GrpcSession): Metadata {
 		const metadata = new Metadata();
 		if (tx !== undefined && tx !== null) {
 			metadata.set("Tigris-Tx-Id", tx.id);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This is the start of supporting HTTP and grpc in the typescript client. All grpc calls are now wrapped behind a grpc driver with a common interface that the HTTP can implement as well. 


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

### Is this change backwards compatible?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why?_

### Does it require updates to [Tigris docs](https://docs.tigrisdata.com/)?

- [ ] Yes, and here is the link: _please create an issue in [tigris-docs](https://github.com/tigrisdata/tigris-docs/issues) repo
      and replace this text as `tigrisdata/tigris-docs#123`_
- [x] No

### Checklist

- [ ] `npm run build` - builds successfully
- [ ] `npm run test` - tests passing
- [ ] `npm run lint` - no lint errors

## [optional] Are there any post deployment tasks we need to perform?
